### PR TITLE
Add local Supermemory launcher

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -1,4 +1,265 @@
 #!/usr/bin/env node
+if (process.argv[2] === "local") {
+  (async () => {
+    const fs = require("node:fs");
+    const fsp = require("node:fs/promises");
+    const os = require("node:os");
+    const path = require("node:path");
+    const https = require("node:https");
+    const { spawn } = require("node:child_process");
+
+    const BIN_NAME = "supermemory-server";
+    const INSTALL_URL = process.env.SUPERMEMORY_LOCAL_INSTALL_URL || "https://supermemory.ai/install";
+    const INSTALL_DIR = path.resolve(process.env.SUPERMEMORY_INSTALL_DIR || path.join(os.homedir(), ".supermemory"));
+    const BIN_DIR = path.join(INSTALL_DIR, "bin");
+    const WRAPPER_BIN_DIR = path.resolve(process.env.SUPERMEMORY_BIN_DIR || path.join(os.homedir(), ".local", "bin"));
+    const ENV_FILE = path.join(INSTALL_DIR, "env");
+
+    function usage() {
+      process.stdout.write(`supermemory local
+
+Run a local self-hosted Supermemory server.
+
+Usage:
+  supermemory local [start] [--version <version>] [--port <port>] [-- <server args>]
+  supermemory local install [--version <version>] [--force]
+  supermemory local upgrade
+  supermemory local status [--url <url>]
+  supermemory local path
+  supermemory local env
+
+Options:
+  --version <version>  Install an explicit server version, for example 0.0.1-rc.4.
+  --port <port>        Port for local start. Defaults to PORT or 8787.
+  --force              Forward a force install hint to the hosted installer.
+  --no-install         Start only if the server binary is already installed.
+
+The SDK package only contains this small launcher. The native server binary and
+runtime assets are installed by ${INSTALL_URL}.
+`);
+    }
+
+    function fail(message) {
+      process.stderr.write(`supermemory local: ${message}\n`);
+      return 1;
+    }
+
+    function parseArgs(argv) {
+      const opts = { command: "start", version: "latest", force: false, install: true, port: undefined, url: undefined, serverArgs: [] };
+      const args = [...argv];
+      if (args[0] && !args[0].startsWith("-")) opts.command = args.shift();
+      while (args.length > 0) {
+        const arg = args.shift();
+        if (arg === "--") {
+          opts.serverArgs = args;
+          break;
+        }
+        if (arg === "--help" || arg === "-h") opts.help = true;
+        else if (arg === "--force") opts.force = true;
+        else if (arg === "--no-install") opts.install = false;
+        else if (arg === "--version") opts.version = args.shift() || "";
+        else if (arg === "--port") opts.port = args.shift() || "";
+        else if (arg === "--url") opts.url = args.shift() || "";
+        else return { ...opts, error: `unknown option ${arg}` };
+      }
+      return opts;
+    }
+
+    function request(url, redirects = 0) {
+      return new Promise((resolve, reject) => {
+        const req = https.get(
+          url,
+          { headers: { "user-agent": "supermemory-sdk-local-installer" } },
+          (res) => {
+            if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+              res.resume();
+              if (redirects > 5) reject(new Error(`too many redirects for ${url}`));
+              else resolve(request(new URL(res.headers.location, url).toString(), redirects + 1));
+              return;
+            }
+            if (res.statusCode < 200 || res.statusCode >= 300) {
+              res.resume();
+              reject(new Error(`request failed (${res.statusCode}) for ${url}`));
+              return;
+            }
+            resolve(res);
+          },
+        );
+        req.on("error", reject);
+      });
+    }
+
+    async function getText(url) {
+      const res = await request(url);
+      let body = "";
+      for await (const chunk of res) body += chunk;
+      return body;
+    }
+
+    async function exists(file) {
+      try {
+        await fsp.access(file, fs.constants.X_OK);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    function installerUrl(version) {
+      if (!version || version === "latest") return INSTALL_URL;
+      const url = new URL(INSTALL_URL);
+      url.searchParams.set("version", version.replace(/^server-v/, ""));
+      return url.toString();
+    }
+
+    function candidateServerBins() {
+      return [
+        path.join(WRAPPER_BIN_DIR, BIN_NAME),
+        path.join(BIN_DIR, BIN_NAME),
+      ];
+    }
+
+    async function resolveServerBin() {
+      for (const candidate of candidateServerBins()) {
+        if (await exists(candidate)) return candidate;
+      }
+      return null;
+    }
+
+    async function runInstallScript(opts, { noStart = true } = {}) {
+      const version = opts.version && opts.version !== "latest" ? opts.version.replace(/^server-v/, "") : "";
+      const url = installerUrl(version);
+      process.stderr.write(`Installing local Supermemory via ${url}\n`);
+      const script = await getText(url);
+      const env = {
+        ...process.env,
+        SUPERMEMORY_INSTALL_DIR: INSTALL_DIR,
+        SUPERMEMORY_BIN_DIR: WRAPPER_BIN_DIR,
+      };
+      if (noStart) env.SUPERMEMORY_NO_START = "1";
+      if (!process.stdin.isTTY) env.SUPERMEMORY_NO_PROMPT = "1";
+      if (opts.force) env.SUPERMEMORY_FORCE = "1";
+      const args = ["-s", "--"];
+      if (version) args.push(version);
+      const child = spawn("bash", args, { stdio: ["pipe", "inherit", "inherit"], env });
+      child.stdin.end(script);
+      const code = await new Promise((resolve) => {
+        child.on("close", (exitCode) => resolve(exitCode || 0));
+        child.on("error", (error) => {
+          process.stderr.write(`failed to run bash installer: ${error.message}\n`);
+          resolve(1);
+        });
+      });
+      const installed = await resolveServerBin();
+      if (code !== 0 && installed) {
+        process.stderr.write(`Installer exited with code ${code} after installing ${installed}; continuing.\n`);
+        return { bin: installed };
+      }
+      if (code !== 0) throw new Error(`installer exited with code ${code}`);
+      if (!installed) throw new Error(`installer completed but ${BIN_NAME} was not found in ${candidateServerBins().join(" or ")}`);
+      return { bin: installed };
+    }
+
+    async function readEnvFile(file) {
+      try {
+        const text = await fsp.readFile(file, "utf8");
+        const env = {};
+        for (const rawLine of text.split(/\r?\n/)) {
+          const line = rawLine.trim();
+          if (!line || line.startsWith("#")) continue;
+          const match = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+          if (!match) continue;
+          let value = match[2];
+          if ((value.startsWith("'") && value.endsWith("'")) || (value.startsWith('"') && value.endsWith('"'))) {
+            value = value.slice(1, -1);
+          }
+          env[match[1]] = value;
+        }
+        return env;
+      } catch (error) {
+        if (error && error.code === "ENOENT") return {};
+        throw error;
+      }
+    }
+
+    async function startServer(opts) {
+      let installed = { bin: await resolveServerBin() };
+      if (!installed.bin) {
+        if (!opts.install) throw new Error(`${BIN_NAME} is not installed. Run supermemory local install first.`);
+        installed = await runInstallScript(opts, { noStart: true });
+      }
+      const envFile = await readEnvFile(ENV_FILE);
+      const env = { ...envFile, ...process.env };
+      if (opts.port) env.PORT = String(opts.port);
+      const child = spawn(installed.bin, opts.serverArgs || [], { stdio: "inherit", env });
+      return await new Promise((resolve) => {
+        child.on("close", (code) => resolve(code || 0));
+        child.on("error", (error) => {
+          process.stderr.write(`failed to start ${installed.bin}: ${error.message}\n`);
+          resolve(1);
+        });
+      });
+    }
+
+    async function status(opts) {
+      const current = await resolveServerBin();
+      const url = opts.url || process.env.SUPERMEMORY_LOCAL_URL || `http://localhost:${opts.port || process.env.PORT || 8787}`;
+      let reachable = false;
+      let detail = "";
+      if (typeof fetch === "function") {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 1500);
+        try {
+          const res = await fetch(url, { signal: controller.signal });
+          reachable = true;
+          detail = `HTTP ${res.status}`;
+        } catch (error) {
+          detail = error && error.name === "AbortError" ? "timed out" : error.message || String(error);
+        } finally {
+          clearTimeout(timeout);
+        }
+      } else {
+        detail = "fetch is unavailable in this Node runtime";
+      }
+      process.stdout.write(`installed: ${current || "no"}\n`);
+      process.stdout.write(`server:    ${reachable ? `reachable (${detail})` : `not reachable (${detail})`}\n`);
+      return current && reachable ? 0 : 1;
+    }
+
+    const opts = parseArgs(process.argv.slice(3));
+    if (opts.help || opts.command === "help") {
+      usage();
+      return 0;
+    }
+    if (opts.error) return fail(opts.error);
+
+    if (opts.command === "install") {
+      await runInstallScript(opts, { noStart: true });
+      return 0;
+    }
+    if (opts.command === "upgrade") {
+      await runInstallScript({ ...opts, version: "latest", force: true }, { noStart: true });
+      return 0;
+    }
+    if (opts.command === "start") return await startServer(opts);
+    if (opts.command === "status") return await status(opts);
+    if (opts.command === "path") {
+      process.stdout.write(`${(await resolveServerBin()) || path.join(WRAPPER_BIN_DIR, BIN_NAME)}\n`);
+      return 0;
+    }
+    if (opts.command === "env") {
+      process.stdout.write(`${ENV_FILE}\n`);
+      return 0;
+    }
+    return fail(`unknown command ${opts.command}`);
+  })()
+    .then((code) => process.exit(code || 0))
+    .catch((error) => {
+      process.stderr.write(`supermemory local: ${error && error.message ? error.message : String(error)}\n`);
+      process.exit(1);
+    });
+  return;
+}
 var __create = Object.create;
 var __getProtoOf = Object.getPrototypeOf;
 var __defProp = Object.defineProperty;

--- a/packages/mcp-server/yarn.lock
+++ b/packages/mcp-server/yarn.lock
@@ -3085,6 +3085,11 @@ minimist@^1.2.5, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+minisearch@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/minisearch/-/minisearch-7.2.0.tgz#3dc30e41e9464b3836553b6d969b656614f8f359"
+  integrity sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==
+
 mkdirp@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-2.1.6.tgz#964fbcb12b2d8c5d6fbc62a963ac95a273e2cc19"
@@ -3803,8 +3808,9 @@ strip-json-comments@^5.0.2:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-5.0.3.tgz#b7304249dd402ee67fd518ada993ab3593458bcf"
   integrity sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==
 
-"supermemory@file:../../dist":
-  version "4.21.0"
+"supermemory@link:../../dist":
+  version "0.0.0"
+  uid ""
 
 superstruct@^1.0.4:
   version "1.0.4"

--- a/src/client.ts
+++ b/src/client.ts
@@ -168,6 +168,41 @@ export interface ClientOptions {
   logger?: Logger | undefined;
 }
 
+export interface LocalClientOptions extends Omit<ClientOptions, 'baseURL'> {
+  /**
+   * Override the local server URL.
+   *
+   * Defaults to process.env['SUPERMEMORY_LOCAL_URL'] or http://localhost:8787.
+   */
+  baseURL?: string | null | undefined;
+
+  /**
+   * Port to use when constructing the default local server URL.
+   *
+   * Defaults to process.env['PORT'] or 8787.
+   */
+  port?: number | undefined;
+
+  /**
+   * Install and start the local server before returning the client.
+   *
+   * @default true
+   */
+  start?: boolean | undefined;
+
+  /**
+   * Install an explicit local server version, for example "0.0.1-rc.4".
+   */
+  version?: string | undefined;
+
+  /**
+   * How long to wait for the local server to become reachable.
+   *
+   * @default 30000
+   */
+  startupTimeout?: number | undefined;
+}
+
 /**
  * API Client for interfacing with the Supermemory API.
  */
@@ -793,6 +828,34 @@ export class Supermemory {
   static Supermemory = this;
   static DEFAULT_TIMEOUT = 60000; // 1 minute
 
+  /**
+   * Create a client for the local Supermemory server.
+   *
+   * By default this installs and starts the local server via the package CLI if
+   * it is not already reachable.
+   */
+  static async local(options: LocalClientOptions = {}): Promise<Supermemory> {
+    const { baseURL, port, start = true, version, startupTimeout = 30000, ...clientOptions } = options;
+    const localBaseURL =
+      baseURL || readEnv('SUPERMEMORY_LOCAL_URL') || `http://localhost:${port ?? readEnv('PORT') ?? 8787}`;
+
+    if (start) {
+      await ensureLocalServer({
+        baseURL: localBaseURL,
+        port,
+        version,
+        timeout: startupTimeout,
+        fetch: clientOptions.fetch,
+      });
+    }
+
+    return new Supermemory({
+      ...clientOptions,
+      apiKey: clientOptions.apiKey ?? readEnv('SUPERMEMORY_API_KEY') ?? 'local',
+      baseURL: localBaseURL,
+    });
+  }
+
   static SupermemoryError = Errors.SupermemoryError;
   static APIError = Errors.APIError;
   static APIConnectionError = Errors.APIConnectionError;
@@ -831,8 +894,142 @@ Supermemory.Search = Search;
 Supermemory.Settings = Settings;
 Supermemory.Connections = Connections;
 
+type EnsureLocalServerOptions = {
+  baseURL: string;
+  port?: number | undefined;
+  version?: string | undefined;
+  timeout: number;
+  fetch?: Fetch | undefined;
+};
+
+async function ensureLocalServer({
+  baseURL,
+  port,
+  version,
+  timeout,
+  fetch,
+}: EnsureLocalServerOptions): Promise<void> {
+  if (await isLocalServerReachable(baseURL, fetch)) return;
+
+  await startLocalServer({ port, version });
+
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (await isLocalServerReachable(baseURL, fetch)) return;
+    await sleep(250);
+  }
+
+  throw new Errors.SupermemoryError(
+    `Timed out waiting for local Supermemory server at ${baseURL}. Try running \`npx supermemory local\` manually.`,
+  );
+}
+
+async function isLocalServerReachable(baseURL: string, fetch: Fetch | undefined): Promise<boolean> {
+  const fetchFn = fetch ?? Shims.getDefaultFetch();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 1000);
+  try {
+    await fetchFn(baseURL, { method: 'GET', signal: controller.signal } as RequestInit);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function startLocalServer({
+  port,
+  version,
+}: {
+  port?: number | undefined;
+  version?: string | undefined;
+}): Promise<void> {
+  const processRef = (globalThis as any).process;
+  if (!processRef?.versions?.node) {
+    throw new Errors.SupermemoryError('Supermemory.local() can only start the server in Node.js.');
+  }
+
+  const [{ spawn }, cliPath] = await Promise.all([import('node:child_process'), resolveLocalCLIPath()]);
+  const args = cliPath ? [cliPath, 'local'] : ['supermemory', 'local'];
+  if (version) args.push('--version', version);
+  if (port !== undefined) args.push('--port', String(port));
+
+  const child =
+    cliPath ?
+      spawn(processRef.execPath, args, {
+        detached: true,
+        stdio: 'ignore',
+        env: { ...processRef.env },
+      })
+    : spawn(args[0]!, args.slice(1), {
+        detached: true,
+        stdio: 'ignore',
+        env: { ...processRef.env },
+      });
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      callback();
+    };
+    child.once('error', (error) => settle(() => reject(error)));
+    setTimeout(() => settle(resolve), 100);
+  });
+
+  child.unref();
+}
+
+async function resolveLocalCLIPath(): Promise<string | undefined> {
+  const processRef = (globalThis as any).process;
+  const [{ existsSync }, pathModule, urlModule] = await Promise.all([
+    import('node:fs'),
+    import('node:path'),
+    import('node:url'),
+  ]);
+  const dirname = await getCurrentModuleDir(pathModule, urlModule);
+  const candidates =
+    dirname ?
+      [
+        pathModule.join(dirname, 'bin', 'cli'),
+        pathModule.join(dirname, '..', 'bin', 'cli'),
+        pathModule.join(dirname, '..', 'dist', 'bin', 'cli'),
+      ]
+    : [];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  if (processRef?.env?.SUPERMEMORY_CLI_PATH && existsSync(processRef.env.SUPERMEMORY_CLI_PATH)) {
+    return processRef.env.SUPERMEMORY_CLI_PATH;
+  }
+
+  return undefined;
+}
+
+async function getCurrentModuleDir(
+  pathModule: typeof import('node:path'),
+  urlModule: typeof import('node:url'),
+): Promise<string | undefined> {
+  try {
+    if (typeof __dirname !== 'undefined') return __dirname;
+  } catch {}
+
+  try {
+    const metaUrl = (0, eval)('import.meta.url') as string | undefined;
+    if (metaUrl?.startsWith('file:')) return pathModule.dirname(urlModule.fileURLToPath(metaUrl));
+  } catch {}
+
+  return undefined;
+}
+
 export declare namespace Supermemory {
   export type RequestOptions = Opts.RequestOptions;
+
+  export { type LocalClientOptions as LocalClientOptions };
 
   export {
     type AddResponse as AddResponse,

--- a/src/internal/shims.ts
+++ b/src/internal/shims.ts
@@ -52,7 +52,7 @@ export function ReadableStreamFrom<T>(iterable: Iterable<T> | AsyncIterable<T>):
     async cancel() {
       await iter.return?.();
     },
-  });
+  } as any);
 }
 
 /**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -19,6 +19,26 @@ describe('instantiate client', () => {
     process.env = env;
   });
 
+  describe('local', () => {
+    test('creates a client pointed at the default local server', async () => {
+      const client = await Supermemory.local({ start: false });
+
+      expect(client.baseURL).toEqual('http://localhost:8787');
+      expect(client.apiKey).toEqual('local');
+    });
+
+    test('respects local client overrides', async () => {
+      const client = await Supermemory.local({
+        start: false,
+        port: 9999,
+        apiKey: 'local-key',
+      });
+
+      expect(client.baseURL).toEqual('http://localhost:9999');
+      expect(client.apiKey).toEqual('local-key');
+    });
+  });
+
   describe('defaultHeaders', () => {
     const client = new Supermemory({
       baseURL: 'http://localhost:5000/',

--- a/tests/uploads.test.ts
+++ b/tests/uploads.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import type { ResponseLike } from 'supermemory/internal/to-file';
 import { toFile } from 'supermemory/core/uploads';
-import { File } from 'node:buffer';
 
 class MyClass {
   name: string = 'foo';
@@ -10,7 +9,7 @@ class MyClass {
 function mockResponse({ url, content }: { url: string; content?: Blob }): ResponseLike {
   return {
     url,
-    blob: async () => content || new Blob([]),
+    blob: async () => (content || new Blob([])) as any,
   };
 }
 
@@ -46,7 +45,7 @@ describe('toFile', () => {
 
   it('extracts a file name from a File', async () => {
     const input = new File(['foo'], 'input.jsonl');
-    const file = await toFile(input);
+    const file = await toFile(input as any);
     expect(file.name).toEqual('input.jsonl');
   });
 
@@ -58,7 +57,7 @@ describe('toFile', () => {
 
   it('does not copy File objects', async () => {
     const input = new File(['foo'], 'input.jsonl', { type: 'jsonl' });
-    const file = await toFile(input);
+    const file = await toFile(input as any);
     expect(file).toBe(input);
     expect(file.name).toEqual('input.jsonl');
     expect(file.type).toBe('jsonl');
@@ -66,7 +65,7 @@ describe('toFile', () => {
 
   it('is assignable to File and Blob', async () => {
     const input = new File(['foo'], 'input.jsonl', { type: 'jsonl' });
-    const result = await toFile(input);
+    const result = await toFile(input as any);
     const file: File = result;
     const blob: Blob = result;
     void file, blob;


### PR DESCRIPTION
## Summary
- add `supermemory local` CLI handling that installs via `https://supermemory.ai/install` and starts the local server
- add `Supermemory.local()` to return a client pointed at the local server, with optional version/start controls
- add tests for local client defaults and overrides, plus required type/build fixes

## Testing
- `./scripts/build`
- `./scripts/lint`
- `npx jest tests/index.test.ts --runInBand`
- `node bin/cli local --help`
- built CJS/ESM smoke checks for `Supermemory.local({ start: false })`