### PR TITLE
 Fix CLI review follow-ups from PR 91

### DIFF
--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -210,14 +210,31 @@ async function handleBatch(
     return exitWithError('validation_error', 'Invalid JSON array from stdin for batch mode', flags);
   }
 
-  const invalidTag =
-    enforcedTags.length > 0 ? items.find((item) => item.tag && !enforcedTags.includes(item.tag)) : undefined;
-  if (invalidTag?.tag) {
-    return exitWithError(
-      'validation_error',
-      `Batch item tag "${invalidTag.tag}" is outside the API key scope: ${enforcedTags.join(', ')}.`,
-      flags,
-    );
+  for (const [index, item] of items.entries()) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      return exitWithError('validation_error', `Batch item ${index + 1} must be an object`, flags);
+    }
+    if (typeof item.content !== 'string' || item.content.trim().length === 0) {
+      return exitWithError(
+        'validation_error',
+        `Batch item ${index + 1} must include non-empty string content`,
+        flags,
+      );
+    }
+    if ('tag' in item && (typeof item.tag !== 'string' || item.tag.trim().length === 0)) {
+      return exitWithError(
+        'validation_error',
+        `Batch item ${index + 1} tag must be a non-empty string`,
+        flags,
+      );
+    }
+    if (item.tag && enforcedTags.length > 0 && !enforcedTags.includes(item.tag)) {
+      return exitWithError(
+        'validation_error',
+        `Batch item tag "${item.tag}" is outside the API key scope: ${enforcedTags.join(', ')}.`,
+        flags,
+      );
+    }
   }
 
   const results: { id: string; status: string }[] = [];

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { basename, resolve } from 'node:path';
 import chalk from 'chalk';
 import { apiRequest, apiRequestFormData } from '../lib/api.js';
+import { getEnforcedTags } from '../lib/config.js';
 import { defineCliCommand } from '../lib/command.js';
 import { ValidationError } from '../lib/errors.js';
 import { exitWithError, isInputInteractive, type OutputFlags, output } from '../lib/output.js';
@@ -58,7 +59,7 @@ export const addCommand = defineCliCommand({
       }
 
       if (args.batch) {
-        return handleBatch(stdinContent, tag, flags);
+        return handleBatch(stdinContent, tag, flags, getEnforcedTags());
       }
 
       return handleTextAdd(stdinContent, tag, args, flags, span);
@@ -189,7 +190,12 @@ async function handleFileAdd(
   );
 }
 
-async function handleBatch(stdinContent: string, tag: string, flags: OutputFlags): Promise<void> {
+async function handleBatch(
+  stdinContent: string,
+  tag: string,
+  flags: OutputFlags,
+  enforcedTags: string[],
+): Promise<void> {
   let items: {
     content: string;
     title?: string;
@@ -202,6 +208,16 @@ async function handleBatch(stdinContent: string, tag: string, flags: OutputFlags
     if (!Array.isArray(items)) throw new Error('Expected JSON array');
   } catch {
     return exitWithError('validation_error', 'Invalid JSON array from stdin for batch mode', flags);
+  }
+
+  const invalidTag =
+    enforcedTags.length > 0 ? items.find((item) => item.tag && !enforcedTags.includes(item.tag)) : undefined;
+  if (invalidTag?.tag) {
+    return exitWithError(
+      'validation_error',
+      `Batch item tag "${invalidTag.tag}" is outside the API key scope: ${enforcedTags.join(', ')}.`,
+      flags,
+    );
   }
 
   const results: { id: string; status: string }[] = [];

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -228,10 +228,43 @@ async function handleBatch(
         flags,
       );
     }
+    if (item.tag && (item.tag.length > 100 || !/^[a-zA-Z0-9_:-]+$/.test(item.tag))) {
+      return exitWithError(
+        'validation_error',
+        `Batch item ${
+          index + 1
+        } tag must be at most 100 characters and contain only letters, numbers, hyphens, underscores, or colons`,
+        flags,
+      );
+    }
     if (item.tag && enforcedTags.length > 0 && !enforcedTags.includes(item.tag)) {
       return exitWithError(
         'validation_error',
         `Batch item tag "${item.tag}" is outside the API key scope: ${enforcedTags.join(', ')}.`,
+        flags,
+      );
+    }
+    if ('title' in item && typeof item.title !== 'string') {
+      return exitWithError('validation_error', `Batch item ${index + 1} title must be a string`, flags);
+    }
+    if (
+      'id' in item &&
+      (typeof item.id !== 'string' || item.id.length > 100 || !/^[a-zA-Z0-9_:-]+$/.test(item.id))
+    ) {
+      return exitWithError(
+        'validation_error',
+        `Batch item ${
+          index + 1
+        } id must be at most 100 characters and contain only letters, numbers, hyphens, underscores, or colons`,
+        flags,
+      );
+    }
+    if ('metadata' in item && !isValidMetadata(item.metadata)) {
+      return exitWithError(
+        'validation_error',
+        `Batch item ${
+          index + 1
+        } metadata must be an object with string, number, boolean, or string-array values`,
         flags,
       );
     }
@@ -257,5 +290,16 @@ async function handleBatch(
     { results, total: results.length },
     () => `${chalk.green('✓')} Added ${results.length} documents in batch`,
     flags,
+  );
+}
+
+function isValidMetadata(value: unknown): value is Record<string, string | number | boolean | string[]> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  return Object.values(value).every(
+    (entry) =>
+      typeof entry === 'string' ||
+      typeof entry === 'number' ||
+      typeof entry === 'boolean' ||
+      (Array.isArray(entry) && entry.every((item) => typeof item === 'string')),
   );
 }

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -76,7 +76,10 @@ export const addCommand = defineCliCommand({
 
     if (content.startsWith('http://') || content.startsWith('https://')) {
       span.setAttribute('contentType', 'url');
-      return handleUrlAdd(content, tag, args, flags);
+      return handleTextAdd(content, tag, args, flags, span, {
+        label: 'URL',
+        source: content,
+      });
     }
 
     const filePath = resolve(content);
@@ -105,6 +108,7 @@ async function handleTextAdd(
   args: Record<string, unknown>,
   flags: OutputFlags,
   span?: { setAttribute: (k: string, v: string | number) => void },
+  display?: { label: string; source: string },
 ): Promise<void> {
   const body: Record<string, unknown> = { content };
   body.containerTag = tag;
@@ -128,47 +132,11 @@ async function handleTextAdd(
   output(
     data,
     () => {
-      const lines = [`${chalk.green('✓')} Added document ${chalk.dim(data.id)} (${data.status ?? 'queued'})`];
-      if (data.containerTag || tag) {
-        lines.push(`  Tag: ${data.containerTag ?? tag}`);
-      }
-      return lines.join('\n');
-    },
-    flags,
-  );
-}
-
-async function handleUrlAdd(
-  url: string,
-  tag: string,
-  args: Record<string, unknown>,
-  flags: OutputFlags,
-): Promise<void> {
-  const body: Record<string, unknown> = { content: url };
-  body.containerTag = tag;
-  if (args.title) body.title = args.title;
-  if (args.id) body.customId = args.id;
-
-  const metadata = parseJsonArg(args.metadata as string | undefined, 'metadata');
-  if (metadata) body.metadata = metadata;
-
-  const { data } = await apiRequest<{
-    id: string;
-    status: string;
-    containerTag?: string;
-  }>('/v3/documents', {
-    method: 'POST',
-    body,
-  });
-
-  output(
-    data,
-    () => {
-      const lines = [
-        `${chalk.green('✓')} Added URL ${chalk.dim(url)} → ${chalk.dim(data.id)} (${
-          data.status ?? 'queued'
-        })`,
-      ];
+      const subject =
+        display ?
+          `${display.label} ${chalk.dim(display.source)} -> ${chalk.dim(data.id)}`
+        : `document ${chalk.dim(data.id)}`;
+      const lines = [`${chalk.green('✓')} Added ${subject} (${data.status ?? 'queued'})`];
       if (data.containerTag || tag) {
         lines.push(`  Tag: ${data.containerTag ?? tag}`);
       }

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -41,8 +41,8 @@ export const loginCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const flags: OutputFlags = { json: args.json };
     const config = resolveConfig();
+    const flags: OutputFlags = { json: args.json, output: config.output };
 
     await withSpan('supermemory.command', { commandName: 'login' }, async () => {
       const apiKey = args['api-key'];
@@ -179,7 +179,8 @@ export const logoutCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const flags: OutputFlags = { json: args.json };
+    const config = resolveConfig();
+    const flags: OutputFlags = { json: args.json, output: config.output };
 
     deleteCredentials();
     clearScopeCache();
@@ -201,8 +202,8 @@ export const whoamiCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const flags: OutputFlags = { json: args.json };
     const config = resolveConfig();
+    const flags: OutputFlags = { json: args.json, output: config.output };
 
     if (!config.apiKey) {
       exitWithError(

--- a/apps/cli/src/commands/billing.ts
+++ b/apps/cli/src/commands/billing.ts
@@ -23,9 +23,9 @@ const billingShowCommand = defineCliCommand({
     output(
       data,
       () => {
-        const usage = data.usage ?? {
-          tokens: { used: 0, limit: 0 },
-          queries: { used: 0, limit: 0 },
+        const usage = {
+          tokens: { used: data.usage?.tokens?.used ?? 0, limit: data.usage?.tokens?.limit ?? 0 },
+          queries: { used: data.usage?.queries?.used ?? 0, limit: data.usage?.queries?.limit ?? 0 },
         };
 
         const pairs: [string, string][] = [['Plan:', chalk.cyan(data.plan ?? 'unknown')]];

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -175,12 +175,12 @@ export const configCommand = defineCommand({
     const firstArg = rawArgs.find((a: string) => !a.startsWith('-'));
     if (firstArg === 'set' || firstArg === 'get') return;
 
-    const flags = { json: args.json as boolean };
     const userConfig = readUserConfig();
     const teamConfig = readTeamConfig();
     const projectConfig = readProjectConfig();
     const credentials = readCredentials();
     const resolved = resolveConfig();
+    const flags = { json: args.json as boolean, output: resolved.output };
 
     const data = {
       resolved: {

--- a/apps/cli/src/commands/connectors.ts
+++ b/apps/cli/src/commands/connectors.ts
@@ -117,12 +117,29 @@ const connectorsConnectCommand = defineCliCommand({
       body,
     });
 
+    let outputAuthUrlOnly = false;
     if (!args.browser) {
-      output(
-        { url: connection.authLink },
-        () => `  Open this URL to authorize ${chalk.bold(provider)}:\n\n  ${chalk.cyan(connection.authLink)}`,
-        flags,
-      );
+      if (shouldOutputJson(flags)) {
+        outputAuthUrlOnly = true;
+        output(
+          {
+            connectionId: connection.id,
+            provider,
+            tag: args.tag ?? null,
+            url: connection.authLink,
+            expiresIn: connection.expiresIn ?? null,
+          },
+          () => '',
+          flags,
+        );
+      } else {
+        output(
+          { url: connection.authLink },
+          () =>
+            `  Open this URL to authorize ${chalk.bold(provider)}:\n\n  ${chalk.cyan(connection.authLink)}`,
+          flags,
+        );
+      }
     } else {
       await openBrowser(connection.authLink);
       if (!shouldOutputJson(flags)) {
@@ -196,7 +213,7 @@ const connectorsConnectCommand = defineCliCommand({
       }
     }
 
-    if (shouldOutputJson(flags)) {
+    if (shouldOutputJson(flags) && !outputAuthUrlOnly) {
       output(
         {
           connectionId: connection.id,

--- a/apps/cli/src/commands/search.ts
+++ b/apps/cli/src/commands/search.ts
@@ -159,7 +159,11 @@ export const searchCommand = defineCliCommand({
             lines.push(`     ${chalk.dim('chunk:')} ${r.chunk}`);
           }
 
-          const meta = [`Score: ${chalk.bold(r.similarity.toFixed(2))}`];
+          const meta = [
+            `Score: ${
+              typeof r.similarity === 'number' ? chalk.bold(r.similarity.toFixed(2)) : chalk.dim('--')
+            }`,
+          ];
           if (r.resultType === 'chunk') meta.push('chunk');
           if (r.version) meta.push(`v${r.version}`);
           if (r.updatedAt) meta.push(`Updated: ${formatRelativeTime(r.updatedAt)}`);

--- a/apps/cli/src/help/index.ts
+++ b/apps/cli/src/help/index.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type { AuthState } from '../lib/config.js';
+import { CLI_VERSION } from '../lib/version.js';
 
 interface CommandSchema {
   description: string;
@@ -523,7 +524,7 @@ export function buildHelpJson(
 
   return {
     name: 'supermemory',
-    version: '0.1.0',
+    version: CLI_VERSION,
     description: 'supermemory — memory layer for AI agents',
     mode,
     ...(scope ? { scope } : {}),

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -238,12 +238,17 @@ async function main() {
     return;
   }
 
+  const errorFlags = {
+    json: rawArgs.includes('--json'),
+    output: resolveConfig().output,
+  };
+
   const firstNonFlag = rawArgs.find((a) => !a.startsWith('-'));
   if (firstNonFlag && !(firstNonFlag in subCommands)) {
     outputError(
       'E_UNKNOWN_COMMAND',
       `Unknown command: ${firstNonFlag}`,
-      { json: rawArgs.includes('--json'), output: resolveConfig().output },
+      errorFlags,
       'Run `supermemory help` to see available commands.',
     );
     process.exitCode = 1;
@@ -254,11 +259,6 @@ async function main() {
   try {
     await runCommand(cli, { rawArgs });
   } catch (err) {
-    const errorFlags = {
-      json: rawArgs.includes('--json'),
-      output: resolveConfig().output,
-    };
-
     if (err instanceof CliError) {
       outputError(err.code, err.message, errorFlags, err.hint);
       process.exitCode = err.exitCode;

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -240,8 +240,12 @@ async function main() {
 
   const firstNonFlag = rawArgs.find((a) => !a.startsWith('-'));
   if (firstNonFlag && !(firstNonFlag in subCommands)) {
-    process.stderr.write(`\n  Unknown command: ${chalk.bold(firstNonFlag)}\n\n`);
-    process.stderr.write(`  Run ${chalk.dim('supermemory help')} to see available commands.\n\n`);
+    outputError(
+      'E_UNKNOWN_COMMAND',
+      `Unknown command: ${firstNonFlag}`,
+      { json: rawArgs.includes('--json'), output: resolveConfig().output },
+      'Run `supermemory help` to see available commands.',
+    );
     process.exitCode = 1;
     await shutdownOtel();
     return;

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -33,6 +33,7 @@ import {
 } from './lib/config.js';
 import { CliError } from './lib/errors.js';
 import { initOtel, shutdownOtel } from './lib/otel.js';
+import { CLI_VERSION } from './lib/version.js';
 
 async function detectScope(): Promise<{
   mode: 'full' | 'scoped';
@@ -148,10 +149,15 @@ async function main() {
     },
   }) as ReturnType<typeof defineCommand>;
 
-  if (mode === 'scoped' && scope?.tag && !process.env.SUPERMEMORY_TAG) {
-    process.env.SUPERMEMORY_TAG = scope.tag;
-    if (scope.tags && scope.tags.length > 1) {
-      process.env.SUPERMEMORY_TAGS = scope.tags.join(',');
+  if (mode === 'scoped' && scope?.tag) {
+    const enforcedTags = scope.tags?.length ? scope.tags : [scope.tag];
+    process.env.SUPERMEMORY_ENFORCED_TAG = enforcedTags[0] ?? scope.tag;
+    process.env.SUPERMEMORY_ENFORCED_TAGS = enforcedTags.join(',');
+    if (!process.env.SUPERMEMORY_TAG) {
+      process.env.SUPERMEMORY_TAG = enforcedTags[0] ?? scope.tag;
+    }
+    if (enforcedTags.length > 1) {
+      process.env.SUPERMEMORY_TAGS = enforcedTags.join(',');
     }
   }
 
@@ -172,7 +178,7 @@ async function main() {
   const cli = defineCommand({
     meta: {
       name: 'supermemory',
-      version: '0.1.0',
+      version: CLI_VERSION,
       description: 'supermemory — memory layer for AI agents',
     },
     subCommands,
@@ -226,7 +232,7 @@ async function main() {
   }
 
   if (rawArgs.length === 1 && rawArgs[0] === '--version') {
-    process.stdout.write('0.1.0\n');
+    process.stdout.write(`${CLI_VERSION}\n`);
     await shutdownOtel();
     return;
   }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -34,6 +34,7 @@ import {
 import { CliError } from './lib/errors.js';
 import { initOtel, shutdownOtel } from './lib/otel.js';
 import { CLI_VERSION } from './lib/version.js';
+import { error as outputError } from './lib/output.js';
 
 async function detectScope(): Promise<{
   mode: 'full' | 'scoped';
@@ -249,28 +250,24 @@ async function main() {
   try {
     await runCommand(cli, { rawArgs });
   } catch (err) {
+    const errorFlags = {
+      json: rawArgs.includes('--json'),
+      output: resolveConfig().output,
+    };
+
     if (err instanceof CliError) {
-      process.stderr.write(`${chalk.red('✗')} ${err.message}\n`);
-      if (err.hint) {
-        process.stderr.write(`  ${chalk.dim(`hint: ${err.hint}`)}\n`);
-      }
+      outputError(err.code, err.message, errorFlags, err.hint);
       process.exitCode = err.exitCode;
     } else if (err instanceof Error && 'code' in err && typeof err.code === 'string') {
-      const { code } = err;
-      process.stderr.write(`\n  ${err.message}\n`);
-      if (code === 'E_UNKNOWN_COMMAND') {
-        process.stderr.write(`\n  Run ${chalk.dim('supermemory help')} to see available commands.\n\n`);
-      } else if (code === 'EARG') {
-        process.stderr.write(`\n  Run the command with ${chalk.dim('--help')} for usage details.\n\n`);
-      } else {
-        process.stderr.write('\n');
-      }
+      const hint =
+        err.code === 'E_UNKNOWN_COMMAND' ? 'Run `supermemory help` to see available commands.'
+        : err.code === 'EARG' ? 'Run the command with `--help` for usage details.'
+        : undefined;
+      outputError(err.code, err.message, errorFlags, hint);
       process.exitCode = 1;
     } else {
-      process.stderr.write(
-        `${chalk.red('✗')} Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`,
-      );
-      if (err instanceof Error && err.stack) {
+      outputError('unexpected_error', err instanceof Error ? err.message : String(err), errorFlags);
+      if (!errorFlags.json && errorFlags.output !== 'json' && err instanceof Error && err.stack) {
         process.stderr.write(`${chalk.dim(err.stack)}\n`);
       }
       process.exitCode = 1;

--- a/apps/cli/src/lib/command.ts
+++ b/apps/cli/src/lib/command.ts
@@ -38,6 +38,7 @@ export function defineCliCommand(options: {
     }
   >;
   noSpan?: boolean;
+  subCommands?: Record<string, ReturnType<typeof defineCommand>>;
   handler: (ctx: CommandContext) => Promise<void>;
 }) {
   const allArgs = {
@@ -52,6 +53,7 @@ export function defineCliCommand(options: {
   return defineCommand({
     meta: options.meta,
     args: allArgs,
+    ...(options.subCommands ? { subCommands: options.subCommands } : {}),
     async run({ args, rawArgs }) {
       const enforcedTags = getEnforcedTags();
       if (args.tag && enforcedTags.length > 0 && !enforcedTags.includes(args.tag as string)) {

--- a/apps/cli/src/lib/command.ts
+++ b/apps/cli/src/lib/command.ts
@@ -1,7 +1,8 @@
 import type { Span } from '@opentelemetry/api';
 import { defineCommand } from 'citty';
 import { getConfig } from './api.js';
-import type { ResolvedConfig } from './config.js';
+import { getEnforcedTags, type ResolvedConfig } from './config.js';
+import { ValidationError } from './errors.js';
 import { withSpan } from './otel.js';
 import type { OutputFlags } from './output.js';
 
@@ -18,6 +19,7 @@ const noopSpan = {
 } as unknown as Span;
 
 export interface CommandContext {
+  rawArgs: string[];
   args: Record<string, unknown>;
   flags: OutputFlags;
   config: ResolvedConfig;
@@ -50,15 +52,22 @@ export function defineCliCommand(options: {
   return defineCommand({
     meta: options.meta,
     args: allArgs,
-    async run({ args }) {
-      const flags: OutputFlags = { json: args.json as boolean };
+    async run({ args, rawArgs }) {
+      const enforcedTags = getEnforcedTags();
+      if (args.tag && enforcedTags.length > 0 && !enforcedTags.includes(args.tag as string)) {
+        throw new ValidationError(
+          `Cannot use --tag "${args.tag}". Your API key is scoped to: ${enforcedTags.join(', ')}.`,
+        );
+      }
       const config = getConfig({
         tag: args.tag as string | undefined,
       });
+      const flags: OutputFlags = { json: args.json as boolean, output: config.output };
 
       const runHandler = async (span: Span) => {
         await options.handler({
           args: args as Record<string, unknown>,
+          rawArgs,
           flags,
           config,
           span,

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import {
   chmodSync,
   existsSync,
+  copyFileSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -63,7 +64,18 @@ export function getScopeCacheDir(): string {
 }
 
 function encodeProjectPath(projectPath: string): string {
-  return projectPath.replace(new RegExp(`\\${sep}`, 'g'), '-');
+  const normalized = resolve(projectPath);
+  const safe = normalized
+    .replace(/^[a-zA-Z]:/, (drive) => drive[0] ?? '')
+    .replace(/[<>:"/\\|?*\x00-\x1F]/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+/g, '-');
+  const hash = createHash('sha256').update(normalized).digest('hex').slice(0, 8);
+  return `${safe || 'root'}-${hash}`;
+}
+
+function encodeLegacyProjectPath(projectPath: string): string {
+  return resolve(projectPath).split(sep).join('-');
 }
 
 export function getProjectDir(): string {
@@ -72,11 +84,16 @@ export function getProjectDir(): string {
   return join(PROJECTS_DIR, encoded);
 }
 
+function getLegacyProjectDir(): string {
+  const cwd = resolve(process.cwd());
+  const encoded = encodeLegacyProjectPath(cwd);
+  return join(PROJECTS_DIR, encoded);
+}
+
 function findTeamConfigDir(): string | null {
   let dir = resolve(process.cwd());
-  const root = sep;
 
-  while (dir !== root) {
+  while (true) {
     const candidate = join(dir, '.supermemory', 'config.json');
     if (existsSync(candidate)) {
       return join(dir, '.supermemory');
@@ -86,9 +103,12 @@ function findTeamConfigDir(): string | null {
       return null;
     }
 
-    dir = resolve(dir, '..');
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
   }
-  return null;
 }
 
 function ensureDir(dir: string): void {
@@ -233,12 +253,23 @@ export function getAuthState(): AuthState {
 
 export function readProjectConfig(): ProjectConfig | null {
   const dir = getProjectDir();
-  return readJsonFile<ProjectConfig>(join(dir, 'config.json'));
+  return (
+    readJsonFile<ProjectConfig>(join(dir, 'config.json')) ??
+    readJsonFile<ProjectConfig>(join(getLegacyProjectDir(), 'config.json'))
+  );
 }
 
 export function writeProjectConfig(config: ProjectConfig): void {
   const dir = getProjectDir();
-  writeJsonFile(join(dir, 'config.json'), config, !!config.apiKey);
+  const configPath = join(dir, 'config.json');
+  writeJsonFile(configPath, config, !!config.apiKey);
+
+  const legacyPath = join(getLegacyProjectDir(), 'config.json');
+  if (legacyPath !== configPath && existsSync(legacyPath)) {
+    try {
+      copyFileSync(configPath, legacyPath);
+    } catch {}
+  }
 }
 
 export function updateProjectConfig(updates: Partial<ProjectConfig>): void {
@@ -288,6 +319,17 @@ export function getKeyScope(): ScopeCache | null {
   return readScopeCache(keyHash);
 }
 
+export function getEnforcedTags(): string[] {
+  const tags = process.env.SUPERMEMORY_ENFORCED_TAGS;
+  if (tags) {
+    return tags
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+  }
+  return process.env.SUPERMEMORY_ENFORCED_TAG ? [process.env.SUPERMEMORY_ENFORCED_TAG] : [];
+}
+
 export function resolveConfig(flags?: { tag?: string }): ResolvedConfig {
   const userConfig = readUserConfig();
   const credentials = readCredentials();
@@ -305,7 +347,14 @@ export function resolveConfig(flags?: { tag?: string }): ResolvedConfig {
 
   const apiKey = envApiKey ?? storedApiKey ?? null;
 
-  const tag = flags?.tag ?? process.env.SUPERMEMORY_TAG ?? teamConfig?.tag ?? projectConfig?.tag ?? null;
+  const enforcedTags = getEnforcedTags();
+  const requestedTag = flags?.tag ?? process.env.SUPERMEMORY_TAG;
+  const tag =
+    enforcedTags.length > 0 ?
+      requestedTag && enforcedTags.includes(requestedTag) ?
+        requestedTag
+      : enforcedTags[0] ?? null
+    : requestedTag ?? teamConfig?.tag ?? projectConfig?.tag ?? null;
 
   const apiUrl = process.env.SUPERMEMORY_API_URL ?? userConfig.apiUrl ?? 'https://api.supermemory.ai';
 

--- a/apps/cli/src/lib/output.ts
+++ b/apps/cli/src/lib/output.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 
 export interface OutputFlags {
   json?: boolean;
+  output?: 'auto' | 'json' | 'human';
 }
 
 export const EXIT = {
@@ -22,6 +23,8 @@ export function isInputInteractive(): boolean {
 
 export function shouldOutputJson(flags: OutputFlags): boolean {
   if (flags.json) return true;
+  if (flags.output === 'json') return true;
+  if (flags.output === 'human') return false;
   return !isInteractive();
 }
 

--- a/apps/cli/src/lib/version.ts
+++ b/apps/cli/src/lib/version.ts
@@ -1,0 +1,3 @@
+import pkg from '../../package.json';
+
+export const CLI_VERSION = pkg.version;


### PR DESCRIPTION
Fixes CLI migration follow-ups around output consistency, scoped keys, project config portability, and command edge cases.

## Changes

- Make project/team config paths Windows-safe and stable across nested working directories.
- Apply resolved human/JSON output consistently, including structured unknown-command and handler errors.
- Enforce scoped-key tags for direct and batch ingestion, with complete batch prevalidation before any request.
- Harden billing, search, connector, version, and URL-ingestion edge cases.

## Testing

- PASS — `PATH="$HOME/.bun/bin:$PATH" ./scripts/lint` with Supermemory API/tag environment variables unset.
  - TypeScript passed, ATTW reported `Types ok!`, and publint reported `All good!`.
- PASS — `./scripts/test` with Supermemory API/tag environment variables unset.
  - 7 suites passed, 6 skipped; 218 tests passed, 43 skipped; 3 snapshots passed.
- PASS — direct CLI checks against an instrumented local API server.
  - Invalid content, tag, title, ID, and metadata batch fields returned JSON validation errors with zero document requests.
  - A valid two-item batch returned `total: 2` and issued exactly two correctly serialized requests.
  - Unknown commands and API failures returned structured JSON errors with exit status 1.

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/fc7700cd-bb25-46f0-898c-f75d2deb1054)
- Requested by: Mahesh Sanikommu (mahesh@supermemory.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
