### PR TITLE
Add plugin login and uninstall commands

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -20,7 +20,8 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.213.0",
     "@opentelemetry/sdk-node": "^0.213.0",
     "chalk": "^5.6.2",
-    "citty": "^0.1.6"
+    "citty": "^0.1.6",
+    "jsonc-parser": "^3.2.1"
   },
   "devDependencies": {
     "@total-typescript/tsconfig": "^1.0.4",

--- a/apps/cli/src/commands/plugin-lifecycle.ts
+++ b/apps/cli/src/commands/plugin-lifecycle.ts
@@ -168,9 +168,7 @@ export function detectInstalledPlugin(id: PluginId): InstalledPlugin {
 
   if (id === 'codex') {
     const hooksDirectory = join(homedir(), '.codex', 'supermemory');
-    const hooksInstalled = ['recall.js', 'flush.js'].every((file) =>
-      existsSync(join(hooksDirectory, file)),
-    );
+    const hooksInstalled = ['recall.js', 'flush.js'].every((file) => existsSync(join(hooksDirectory, file)));
     const skillsInstalled = existsSync(join(homedir(), '.codex', 'skills', 'supermemory-search'));
     return {
       installed: hooksInstalled || skillsInstalled,

--- a/apps/cli/src/commands/plugin-lifecycle.ts
+++ b/apps/cli/src/commands/plugin-lifecycle.ts
@@ -53,7 +53,7 @@ function readInstallState(): PluginInstallState {
 
 function writeInstallState(state: PluginInstallState): void {
   mkdirSync(dirname(PLUGIN_INSTALL_STATE_PATH), { recursive: true });
-  writeFileSync(PLUGIN_INSTALL_STATE_PATH, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  writeFileSync(PLUGIN_INSTALL_STATE_PATH, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
   try {
     chmodSync(PLUGIN_INSTALL_STATE_PATH, 0o600);
   } catch {}
@@ -222,7 +222,7 @@ export async function getLatestPluginVersion(id: PluginId): Promise<string | und
     const executable = process.platform === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : 'npm';
     const args =
       process.platform === 'win32' ?
-        ['/d', '/s', '/c', 'npm view ' + packageName + ' version --json']
+        ['/d', '/s', '/c', `npm view ${packageName} version --json`]
       : ['view', packageName, 'version', '--json'];
     const result = spawnSync(executable, args, {
       encoding: 'utf8',
@@ -251,7 +251,7 @@ export function removeOpenCodePlugin(): string[] {
       formattingOptions: { insertSpaces: true, tabSize: 2 },
     });
     writeFileSync(path, applyEdits(content, edits), 'utf8');
-    steps.push('removed opencode-supermemory from ' + path);
+    steps.push(`removed opencode-supermemory from ${path}`);
   }
 
   const commandDirectory = join(homedir(), '.config', 'opencode', 'command');
@@ -259,7 +259,7 @@ export function removeOpenCodePlugin(): string[] {
     const path = join(commandDirectory, file);
     if (!existsSync(path)) continue;
     unlinkSync(path);
-    steps.push('removed ' + path);
+    steps.push(`removed ${path}`);
   }
   return steps;
 }

--- a/apps/cli/src/commands/plugin-lifecycle.ts
+++ b/apps/cli/src/commands/plugin-lifecycle.ts
@@ -5,10 +5,12 @@ import { dirname, join } from 'node:path';
 import { applyEdits, modify, parse } from 'jsonc-parser/lib/esm/main.js';
 
 export type PluginId = 'claude' | 'cursor' | 'opencode' | 'codex';
+export type ClaudePluginScope = 'user' | 'project' | 'local';
 
 export interface InstalledPlugin {
   installed: boolean;
   version?: string;
+  scopes?: ClaudePluginScope[];
 }
 
 interface PluginInstallState {
@@ -91,6 +93,32 @@ function findClaudePluginVersion(value: unknown): string | undefined {
   return undefined;
 }
 
+function findClaudePluginScopes(value: unknown): ClaudePluginScope[] {
+  const scopes = new Set<ClaudePluginScope>();
+  const visit = (entry: unknown): void => {
+    if (Array.isArray(entry)) {
+      entry.forEach(visit);
+      return;
+    }
+    if (!entry || typeof entry !== 'object') return;
+
+    const record = entry as Record<string, unknown>;
+    const identity = [record.id, record.name, record.plugin, record.pluginId, record.source]
+      .filter((item): item is string => typeof item === 'string')
+      .join(' ');
+    if (/supermemory(?:@supermemory-plugins)?/i.test(identity)) {
+      const scope = [record.scope, record.installationScope, record.installation_scope].find(
+        (item): item is string => typeof item === 'string',
+      );
+      if (scope === 'user' || scope === 'project' || scope === 'local') scopes.add(scope);
+    }
+    Object.values(record).forEach(visit);
+  };
+
+  visit(value);
+  return [...scopes];
+}
+
 export function getOpenCodeConfigPaths(): string[] {
   const directory = join(homedir(), '.config', 'opencode');
   return [join(directory, 'opencode.jsonc'), join(directory, 'opencode.json')];
@@ -161,12 +189,16 @@ export function detectInstalledPlugin(id: PluginId): InstalledPlugin {
   });
   const output = result.stdout ?? '';
   let version: string | undefined;
+  let scopes: ClaudePluginScope[] = [];
   try {
-    version = findClaudePluginVersion(JSON.parse(output));
+    const parsed = JSON.parse(output);
+    version = findClaudePluginVersion(parsed);
+    scopes = findClaudePluginScopes(parsed);
   } catch {}
   return {
     installed: result.status === 0 && /supermemory/i.test(output),
     version: version ?? recordedVersion,
+    scopes: scopes.length > 0 ? scopes : undefined,
   };
 }
 

--- a/apps/cli/src/commands/plugin-lifecycle.ts
+++ b/apps/cli/src/commands/plugin-lifecycle.ts
@@ -169,9 +169,15 @@ export function detectInstalledPlugin(id: PluginId): InstalledPlugin {
   if (id === 'codex') {
     const hooksDirectory = join(homedir(), '.codex', 'supermemory');
     const hooksInstalled = ['recall.js', 'flush.js'].every((file) => existsSync(join(hooksDirectory, file)));
-    const skillsInstalled = existsSync(join(homedir(), '.codex', 'skills', 'supermemory-search'));
+    const skillsDirectory = join(homedir(), '.codex', 'skills');
+    const skillsInstalled = [
+      'supermemory-forget',
+      'supermemory-login',
+      'supermemory-save',
+      'supermemory-search',
+    ].every((skill) => existsSync(join(skillsDirectory, skill, 'SKILL.md')));
     return {
-      installed: hooksInstalled || skillsInstalled,
+      installed: hooksInstalled && skillsInstalled,
       version: recordedVersion,
     };
   }

--- a/apps/cli/src/commands/plugin-lifecycle.ts
+++ b/apps/cli/src/commands/plugin-lifecycle.ts
@@ -1,0 +1,267 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { applyEdits, modify, parse } from 'jsonc-parser/lib/esm/main.js';
+
+export type PluginId = 'claude' | 'cursor' | 'opencode' | 'codex';
+
+export interface InstalledPlugin {
+  installed: boolean;
+  version?: string;
+}
+
+interface PluginInstallState {
+  plugins: Partial<Record<PluginId, { version: string; installedAt: string }>>;
+}
+
+const CURSOR_PLUGIN_TARGET = join(
+  homedir(),
+  '.cursor',
+  'plugins',
+  'local',
+  'cursor-supermemory',
+);
+const PLUGIN_INSTALL_STATE_PATH = join(homedir(), '.supermemory', 'plugin-installs.json');
+const OPENCODE_COMMAND_FILES = [
+  'supermemory-init.md',
+  'supermemory-login.md',
+  'supermemory-logout.md',
+  'supermemory-status.md',
+];
+const NPM_PACKAGES: Partial<Record<PluginId, string>> = {
+  cursor: 'cursor-supermemory',
+  opencode: 'opencode-supermemory',
+  codex: 'codex-supermemory',
+};
+
+function readInstallState(): PluginInstallState {
+  try {
+    const value = JSON.parse(readFileSync(PLUGIN_INSTALL_STATE_PATH, 'utf8')) as PluginInstallState;
+    return { plugins: value.plugins ?? {} };
+  } catch {
+    return { plugins: {} };
+  }
+}
+
+function writeInstallState(state: PluginInstallState): void {
+  mkdirSync(dirname(PLUGIN_INSTALL_STATE_PATH), { recursive: true });
+  writeFileSync(PLUGIN_INSTALL_STATE_PATH, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  try {
+    chmodSync(PLUGIN_INSTALL_STATE_PATH, 0o600);
+  } catch {}
+}
+
+export function recordPluginVersion(id: PluginId, version: string): void {
+  const state = readInstallState();
+  state.plugins[id] = { version, installedAt: new Date().toISOString() };
+  writeInstallState(state);
+}
+
+export function forgetPluginVersion(id: PluginId): void {
+  const state = readInstallState();
+  delete state.plugins[id];
+  writeInstallState(state);
+}
+
+function readPackageVersion(path: string): string | undefined {
+  try {
+    const value = JSON.parse(readFileSync(path, 'utf8')) as { version?: unknown };
+    return typeof value.version === 'string' ? value.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function findClaudePluginVersion(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const version = findClaudePluginVersion(item);
+      if (version) return version;
+    }
+    return undefined;
+  }
+  if (!value || typeof value !== 'object') return undefined;
+
+  const record = value as Record<string, unknown>;
+  const identity = [record.id, record.name, record.plugin, record.pluginId, record.source]
+    .filter((entry): entry is string => typeof entry === 'string')
+    .join(' ');
+  if (/supermemory(?:@supermemory-plugins)?/i.test(identity) && typeof record.version === 'string') {
+    return record.version;
+  }
+  for (const child of Object.values(record)) {
+    const version = findClaudePluginVersion(child);
+    if (version) return version;
+  }
+  return undefined;
+}
+
+export function getOpenCodeConfigPaths(): string[] {
+  const directory = join(homedir(), '.config', 'opencode');
+  return [join(directory, 'opencode.jsonc'), join(directory, 'opencode.json')];
+}
+
+function isOpenCodeSupermemoryEntry(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    /(?:^|[/\\])opencode-supermemory(?:@|[/\\]|$)/i.test(value)
+  );
+}
+
+function openCodeConfigHasPlugin(path: string): boolean {
+  if (!existsSync(path)) return false;
+  try {
+    const config = parse(readFileSync(path, 'utf8')) as { plugin?: unknown };
+    return Array.isArray(config?.plugin) && config.plugin.some(isOpenCodeSupermemoryEntry);
+  } catch {
+    return false;
+  }
+}
+
+export function detectInstalledPlugin(id: PluginId): InstalledPlugin {
+  const recordedVersion = readInstallState().plugins[id]?.version;
+
+  if (id === 'cursor') {
+    return {
+      installed: existsSync(join(CURSOR_PLUGIN_TARGET, '.cursor-plugin', 'plugin.json')),
+      version: readPackageVersion(join(CURSOR_PLUGIN_TARGET, 'package.json')) ?? recordedVersion,
+    };
+  }
+
+  if (id === 'opencode') {
+    const manifests = [
+      join(homedir(), '.cache', 'opencode', 'node_modules', 'opencode-supermemory', 'package.json'),
+      join(homedir(), '.config', 'opencode', 'node_modules', 'opencode-supermemory', 'package.json'),
+      join(
+        process.env.LOCALAPPDATA ?? '',
+        'opencode',
+        'node_modules',
+        'opencode-supermemory',
+        'package.json',
+      ),
+    ];
+    return {
+      installed: getOpenCodeConfigPaths().some(openCodeConfigHasPlugin),
+      version: manifests.map(readPackageVersion).find(Boolean) ?? recordedVersion,
+    };
+  }
+
+  if (id === 'codex') {
+    const hook = join(homedir(), '.codex', 'supermemory', 'session-start.js');
+    let version: string | undefined;
+    try {
+      version = readFileSync(hook, 'utf8').match(/PLUGIN_VERSION\s*=\s*['"]([^'"]+)['"]/)?.[1];
+    } catch {}
+    return {
+      installed:
+        existsSync(hook) || existsSync(join(homedir(), '.codex', 'skills', 'supermemory-search')),
+      version: version ?? recordedVersion,
+    };
+  }
+
+  const executable = process.platform === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : 'claude';
+  const args =
+    process.platform === 'win32' ?
+      ['/d', '/s', '/c', 'claude plugin list --json']
+    : ['plugin', 'list', '--json'];
+  const result = spawnSync(executable, args, {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  const output = result.stdout ?? '';
+  let version: string | undefined;
+  try {
+    version = findClaudePluginVersion(JSON.parse(output));
+  } catch {}
+  return {
+    installed: result.status === 0 && /supermemory/i.test(output),
+    version: version ?? recordedVersion,
+  };
+}
+
+export function compareVersions(left: string, right: string): number {
+  const parseVersion = (value: string) => {
+    const [core, prerelease] = value.trim().replace(/^v/i, '').split('-', 2);
+    const numbers = (core ?? '').split('.').map((part) => Number.parseInt(part, 10) || 0);
+    return { numbers, prerelease };
+  };
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  for (let index = 0; index < 3; index += 1) {
+    const difference = (a.numbers[index] ?? 0) - (b.numbers[index] ?? 0);
+    if (difference !== 0) return difference;
+  }
+  if (a.prerelease === b.prerelease) return 0;
+  if (!a.prerelease) return 1;
+  if (!b.prerelease) return -1;
+  return a.prerelease.localeCompare(b.prerelease, undefined, { numeric: true });
+}
+
+export async function getLatestPluginVersion(id: PluginId): Promise<string | undefined> {
+  try {
+    if (id === 'claude') {
+      const response = await fetch(
+        'https://raw.githubusercontent.com/supermemoryai/claude-supermemory/main/latest.json',
+        { signal: AbortSignal.timeout(5000) },
+      );
+      if (!response.ok) return undefined;
+      const value = (await response.json()) as { version?: unknown };
+      return typeof value.version === 'string' ? value.version : undefined;
+    }
+
+    const packageName = NPM_PACKAGES[id];
+    if (!packageName) return undefined;
+    const executable = process.platform === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : 'npm';
+    const args =
+      process.platform === 'win32' ?
+        ['/d', '/s', '/c', 'npm view ' + packageName + ' version --json']
+      : ['view', packageName, 'version', '--json'];
+    const result = spawnSync(executable, args, {
+      encoding: 'utf8',
+      windowsHide: true,
+      timeout: 10_000,
+    });
+    if (result.status !== 0) return undefined;
+    return result.stdout.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/)?.[0];
+  } catch {
+    return undefined;
+  }
+}
+
+export function removeOpenCodePlugin(): string[] {
+  const steps: string[] = [];
+  for (const path of getOpenCodeConfigPaths()) {
+    if (!existsSync(path)) continue;
+    const content = readFileSync(path, 'utf8');
+    const config = parse(content) as { plugin?: unknown };
+    if (!Array.isArray(config?.plugin)) continue;
+    const plugins = config.plugin.filter(
+      (entry) => !isOpenCodeSupermemoryEntry(entry),
+    );
+    if (plugins.length === config.plugin.length) continue;
+    const edits = modify(content, ['plugin'], plugins.length > 0 ? plugins : undefined, {
+      formattingOptions: { insertSpaces: true, tabSize: 2 },
+    });
+    writeFileSync(path, applyEdits(content, edits), 'utf8');
+    steps.push('removed opencode-supermemory from ' + path);
+  }
+
+  const commandDirectory = join(homedir(), '.config', 'opencode', 'command');
+  for (const file of OPENCODE_COMMAND_FILES) {
+    const path = join(commandDirectory, file);
+    if (!existsSync(path)) continue;
+    unlinkSync(path);
+    steps.push('removed ' + path);
+  }
+  return steps;
+}
+
+export { CURSOR_PLUGIN_TARGET };

--- a/apps/cli/src/commands/plugin-lifecycle.ts
+++ b/apps/cli/src/commands/plugin-lifecycle.ts
@@ -1,12 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  unlinkSync,
-  writeFileSync,
-} from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { applyEdits, modify, parse } from 'jsonc-parser/lib/esm/main.js';
@@ -22,13 +15,7 @@ interface PluginInstallState {
   plugins: Partial<Record<PluginId, { version: string; installedAt: string }>>;
 }
 
-const CURSOR_PLUGIN_TARGET = join(
-  homedir(),
-  '.cursor',
-  'plugins',
-  'local',
-  'cursor-supermemory',
-);
+const CURSOR_PLUGIN_TARGET = join(homedir(), '.cursor', 'plugins', 'local', 'cursor-supermemory');
 const PLUGIN_INSTALL_STATE_PATH = join(homedir(), '.supermemory', 'plugin-installs.json');
 const OPENCODE_COMMAND_FILES = [
   'supermemory-init.md',
@@ -110,10 +97,7 @@ export function getOpenCodeConfigPaths(): string[] {
 }
 
 function isOpenCodeSupermemoryEntry(value: unknown): value is string {
-  return (
-    typeof value === 'string' &&
-    /(?:^|[/\\])opencode-supermemory(?:@|[/\\]|$)/i.test(value)
-  );
+  return typeof value === 'string' && /(?:^|[/\\])opencode-supermemory(?:@|[/\\]|$)/i.test(value);
 }
 
 function openCodeConfigHasPlugin(path: string): boolean {
@@ -161,13 +145,12 @@ export function detectInstalledPlugin(id: PluginId): InstalledPlugin {
       version = readFileSync(hook, 'utf8').match(/PLUGIN_VERSION\s*=\s*['"]([^'"]+)['"]/)?.[1];
     } catch {}
     return {
-      installed:
-        existsSync(hook) || existsSync(join(homedir(), '.codex', 'skills', 'supermemory-search')),
+      installed: existsSync(hook) || existsSync(join(homedir(), '.codex', 'skills', 'supermemory-search')),
       version: version ?? recordedVersion,
     };
   }
 
-  const executable = process.platform === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : 'claude';
+  const executable = process.platform === 'win32' ? process.env.ComSpec ?? 'cmd.exe' : 'claude';
   const args =
     process.platform === 'win32' ?
       ['/d', '/s', '/c', 'claude plugin list --json']
@@ -219,7 +202,7 @@ export async function getLatestPluginVersion(id: PluginId): Promise<string | und
 
     const packageName = NPM_PACKAGES[id];
     if (!packageName) return undefined;
-    const executable = process.platform === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : 'npm';
+    const executable = process.platform === 'win32' ? process.env.ComSpec ?? 'cmd.exe' : 'npm';
     const args =
       process.platform === 'win32' ?
         ['/d', '/s', '/c', `npm view ${packageName} version --json`]
@@ -243,9 +226,7 @@ export function removeOpenCodePlugin(): string[] {
     const content = readFileSync(path, 'utf8');
     const config = parse(content) as { plugin?: unknown };
     if (!Array.isArray(config?.plugin)) continue;
-    const plugins = config.plugin.filter(
-      (entry) => !isOpenCodeSupermemoryEntry(entry),
-    );
+    const plugins = config.plugin.filter((entry) => !isOpenCodeSupermemoryEntry(entry));
     if (plugins.length === config.plugin.length) continue;
     const edits = modify(content, ['plugin'], plugins.length > 0 ? plugins : undefined, {
       formattingOptions: { insertSpaces: true, tabSize: 2 },

--- a/apps/cli/src/commands/plugin-lifecycle.ts
+++ b/apps/cli/src/commands/plugin-lifecycle.ts
@@ -167,14 +167,14 @@ export function detectInstalledPlugin(id: PluginId): InstalledPlugin {
   }
 
   if (id === 'codex') {
-    const hook = join(homedir(), '.codex', 'supermemory', 'session-start.js');
-    let version: string | undefined;
-    try {
-      version = readFileSync(hook, 'utf8').match(/PLUGIN_VERSION\s*=\s*['"]([^'"]+)['"]/)?.[1];
-    } catch {}
+    const hooksDirectory = join(homedir(), '.codex', 'supermemory');
+    const hooksInstalled = ['recall.js', 'flush.js'].every((file) =>
+      existsSync(join(hooksDirectory, file)),
+    );
+    const skillsInstalled = existsSync(join(homedir(), '.codex', 'skills', 'supermemory-search'));
     return {
-      installed: existsSync(hook) || existsSync(join(homedir(), '.codex', 'skills', 'supermemory-search')),
-      version: version ?? recordedVersion,
+      installed: hooksInstalled || skillsInstalled,
+      version: recordedVersion,
     };
   }
 

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -166,7 +166,10 @@ function finishArrowPrompt(message: string, value: string): void {
   process.stderr.write(`${chalk.cyan(TUI_BAR)}\n`);
 }
 
-function withRawKeypress<T>(render: () => number, onKey: (key: { name?: string; ctrl?: boolean }) => T | undefined): Promise<T> {
+function withRawKeypress<T>(
+  render: () => number,
+  onKey: (key: { name?: string; ctrl?: boolean }) => T | undefined,
+): Promise<T> {
   const input = process.stdin as NodeJS.ReadStream & { setRawMode?: (mode: boolean) => void };
   const hadRawMode = Boolean(input.isRaw);
   let renderedLines = 0;
@@ -244,7 +247,9 @@ async function arrowSelect<T extends string>(opts: {
         lines.push(`${chalk.cyan(TUI_BAR)} ${pointer} ${marker} ${label}${hint}`);
       }
       lines.push(`${chalk.cyan(TUI_BAR)}`);
-      lines.push(`${chalk.cyan(TUI_BOTTOM)} ${chalk.dim(opts.footer ?? 'Up/Down move, Enter confirm, Esc cancel')}`);
+      lines.push(
+        `${chalk.cyan(TUI_BOTTOM)} ${chalk.dim(opts.footer ?? 'Up/Down move, Enter confirm, Esc cancel')}`,
+      );
       process.stderr.write(`${lines.join('\n')}\n`);
       return lines.length;
     },
@@ -292,7 +297,11 @@ async function arrowMultiselect<T extends string>(opts: {
       }
       if (error) lines.push(`${chalk.yellow(TUI_BAR)} ${chalk.yellow(error)}`);
       lines.push(`${chalk.cyan(TUI_BAR)}`);
-      lines.push(`${chalk.cyan(TUI_BOTTOM)} ${chalk.dim(opts.footer ?? 'Up/Down move, Space select, Enter confirm, Esc back')}`);
+      lines.push(
+        `${chalk.cyan(TUI_BOTTOM)} ${chalk.dim(
+          opts.footer ?? 'Up/Down move, Space select, Enter confirm, Esc back',
+        )}`,
+      );
       process.stderr.write(`${lines.join('\n')}\n`);
       return lines.length;
     },
@@ -522,11 +531,15 @@ function printDetectionSummary(detections: Map<PluginId, Detection>) {
       );
     } else {
       process.stderr.write(
-        `${chalk.cyan(TUI_BAR)}   ${chalk.red('[missing]')} ${chalk.bold(target.label)} ${chalk.dim('not detected')}\n`,
+        `${chalk.cyan(TUI_BAR)}   ${chalk.red('[missing]')} ${chalk.bold(target.label)} ${chalk.dim(
+          'not detected',
+        )}\n`,
       );
     }
   }
-  process.stderr.write(`${chalk.cyan(TUI_BOTTOM)} ${chalk.dim('scripts can use supermemory plugin --all')}\n\n`);
+  process.stderr.write(
+    `${chalk.cyan(TUI_BOTTOM)} ${chalk.dim('scripts can use supermemory plugin --all')}\n\n`,
+  );
 }
 
 function parseOnly(value: unknown): PluginId[] {
@@ -896,7 +909,9 @@ async function authorizePlugins(
         await openBrowser(authUrl);
       } catch {
         spinner?.message('Could not open browser automatically.');
-        process.stdout.write(`  Open this URL to authorize selected plugins:\n\n  ${chalk.cyan(authUrl)}\n\n`);
+        process.stdout.write(
+          `  Open this URL to authorize selected plugins:\n\n  ${chalk.cyan(authUrl)}\n\n`,
+        );
       }
     }
 
@@ -937,7 +952,7 @@ async function authorizePlugins(
         error instanceof Error ? error.message : String(error)
       }\n\n`,
     );
-    process.stdout.write("  Rerun the command to open a fresh OAuth callback and upgrade link.\n\n");
+    process.stdout.write('  Rerun the command to open a fresh OAuth callback and upgrade link.\n\n');
     return true;
   } finally {
     callback.close();
@@ -1217,7 +1232,9 @@ export async function loginInstalledPlugins(options: {
   const missing = selectedIds.filter((id) => !targets.some((target) => target.id === id));
   if (missing.length > 0) {
     throw new Error(
-      `Not installed: ${missing.map((id) => TARGETS.find((target) => target.id === id)?.label ?? id).join(', ')}. Run supermemory plugin first.`,
+      `Not installed: ${missing
+        .map((id) => TARGETS.find((target) => target.id === id)?.label ?? id)
+        .join(', ')}. Run supermemory plugin first.`,
     );
   }
 
@@ -1439,7 +1456,6 @@ export const uninstallCommand = defineCliCommand({
   },
 });
 
-
 export const pluginCommand = defineCliCommand({
   meta: {
     name: 'plugin',
@@ -1535,11 +1551,7 @@ export const pluginCommand = defineCliCommand({
       const shouldInstall =
         force ||
         !installed.installed ||
-        Boolean(
-          installed.version &&
-            latestVersion &&
-            compareVersions(installed.version, latestVersion) < 0,
-        );
+        Boolean(installed.version && latestVersion && compareVersions(installed.version, latestVersion) < 0);
 
       if (!shouldInstall) {
         results.push({
@@ -1558,8 +1570,7 @@ export const pluginCommand = defineCliCommand({
       const result = await installTarget(target, dryRun);
       results.push(result);
       if (!dryRun && result.status === 'installed') {
-        const detectedVersion =
-          latestVersion ?? detectInstalledPlugin(id).version ?? installed.version;
+        const detectedVersion = latestVersion ?? detectInstalledPlugin(id).version ?? installed.version;
         if (detectedVersion) recordPluginVersion(id, detectedVersion);
       }
     }

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -93,14 +93,14 @@ interface ArrowPromptOption<T extends string> {
 }
 
 const SUPERMEMORY_GLYPHS: Record<string, string[]> = {
-  S: ['11111', '10000', '10000', '11110', '00001', '00001', '11110'],
-  U: ['10001', '10001', '10001', '10001', '10001', '10001', '01110'],
-  P: ['11110', '10001', '10001', '11110', '10000', '10000', '10000'],
-  E: ['11111', '10000', '10000', '11110', '10000', '10000', '11111'],
-  R: ['11110', '10001', '10001', '11110', '10100', '10010', '10001'],
-  M: ['10001', '11011', '10101', '10101', '10001', '10001', '10001'],
-  O: ['01110', '10001', '10001', '10001', '10001', '10001', '01110'],
-  Y: ['10001', '10001', '01010', '00100', '00100', '00100', '00100'],
+  S: ['11111', '10000', '11111', '00001', '11111'],
+  U: ['10001', '10001', '10001', '10001', '01110'],
+  P: ['11110', '10001', '11110', '10000', '10000'],
+  E: ['11111', '10000', '11110', '10000', '11111'],
+  R: ['11110', '10001', '11110', '10100', '10010'],
+  M: ['10001', '11011', '10101', '10001', '10001'],
+  O: ['01110', '10001', '10001', '10001', '01110'],
+  Y: ['10001', '01010', '00100', '00100', '00100'],
 };
 
 const SUPERMEMORY_WORD = 'SUPERMEMORY';
@@ -112,7 +112,7 @@ const BANNER_SHADOW_COLOR = '#071D82';
 function printSupermemoryBanner(): void {
   const glyphWidth = 5;
   const glyphGap = 1;
-  const rowCount = 7;
+  const rowCount = 5;
   const columnCount = SUPERMEMORY_WORD.length * (glyphWidth + glyphGap) - glyphGap;
   const isFilled = (row: number, column: number): boolean => {
     if (row < 0 || row >= rowCount || column < 0 || column >= columnCount) return false;
@@ -142,7 +142,7 @@ function printSupermemoryBanner(): void {
   }
 
   const label = chalk.hex('#18BFFF')('>') + chalk.hex('#1775EF').bold(' PLUGINS');
-  const labelPadding = Math.max(2, columnCount - 2 - '> PLUGINS'.length);
+  const labelPadding = Math.max(2, columnCount + 1 - '> PLUGINS'.length);
   process.stderr.write(`${' '.repeat(labelPadding)}${label}\n\n`);
 }
 function clearRenderedPrompt(renderedLines: number): void {

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -1533,8 +1533,7 @@ export const pluginCommand = defineCliCommand({
         force ||
         !installed.installed ||
         Boolean(
-          latestVersion &&
-            (!installed.version || compareVersions(installed.version, latestVersion) < 0),
+          latestVersion && (!installed.version || compareVersions(installed.version, latestVersion) < 0),
         );
 
       if (!shouldInstall) {

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -30,7 +30,7 @@ import {
   recordPluginVersion,
   removeOpenCodePlugin,
 } from './plugin-lifecycle.js';
-import { isInputInteractive, isInteractive } from '../lib/output.js';
+import { isInputInteractive, isInteractive, type OutputFlags, shouldOutputJson } from '../lib/output.js';
 
 type PluginClientId = 'claude_code' | 'cursor' | 'opencode' | 'codex';
 type InstallMode = 'all' | 'custom';
@@ -955,7 +955,7 @@ async function authorizePlugins(
     }
 
     printPluginAuthSummary(authResults);
-    return authResults.some((result) => result.status === 'failed');
+    return authResults.some((result) => result.status !== 'connected');
   } catch (error) {
     spinner?.stop('OAuth failed');
     process.stdout.write(
@@ -1029,11 +1029,22 @@ async function installTarget(target: PluginTarget, dryRun: boolean): Promise<Ins
 
     if (target.id === 'claude') {
       const addMarketplace = ['plugin', 'marketplace', 'add', 'supermemoryai/claude-supermemory'];
+      const updateMarketplace = ['plugin', 'marketplace', 'update', 'supermemory-plugins'];
       const installPlugin = ['plugin', 'install', 'supermemory@supermemory-plugins', '--scope', 'user'];
-      steps.push(formatStep('claude', addMarketplace));
+      steps.push(`${formatStep('claude', updateMarketplace)} (or add it when not registered)`);
       steps.push(formatStep('claude', installPlugin));
       if (!dryRun) {
-        log = await runProcess('claude', addMarketplace);
+        try {
+          log = await runProcess('claude', updateMarketplace);
+        } catch (error) {
+          if (
+            !(error instanceof CommandError) ||
+            !/not found|does not exist|unknown|not registered/i.test(error.log)
+          ) {
+            throw error;
+          }
+          log = await runProcess('claude', addMarketplace);
+        }
         log = (await runProcess('claude', installPlugin)) ?? log;
       }
     }
@@ -1372,23 +1383,21 @@ function printUninstallSummary(results: UninstallResult[], dryRun: boolean): voi
   }
 }
 
-async function handlePluginUninstall(
-  args: Record<string, unknown>,
-  flags: { json?: boolean },
-): Promise<void> {
+async function handlePluginUninstall(args: Record<string, unknown>, flags: OutputFlags): Promise<void> {
   const dryRun = args['dry-run'] === true;
+  const jsonOutput = shouldOutputJson(flags);
   const installed = installedTargets();
   let selectedIds = parseOnly(args.only);
   if (args.all === true) selectedIds = installed.map((target) => target.id);
 
   if (selectedIds.length === 0 && args.all !== true) {
-    if (!isInputInteractive() || flags.json) {
+    if (!isInputInteractive() || jsonOutput) {
       throw new Error('Choose targets with --all or --only claude,cursor,opencode,codex');
     }
     selectedIds = await chooseInstalledTargetIds('remove');
   }
   if (selectedIds.length === 0) {
-    if (flags.json) {
+    if (jsonOutput) {
       process.stdout.write(`${JSON.stringify({ results: [] }, null, 2)}\n`);
     } else {
       process.stdout.write(`\n${chalk.yellow('[skip]')} No installed Supermemory plugins found.\n\n`);
@@ -1413,7 +1422,7 @@ async function handlePluginUninstall(
     results.push(await uninstallTarget(target, dryRun));
   }
 
-  if (flags.json) process.stdout.write(`${JSON.stringify({ results }, null, 2)}\n`);
+  if (jsonOutput) process.stdout.write(`${JSON.stringify({ results }, null, 2)}\n`);
   else printUninstallSummary(results, dryRun);
   if (results.some((result) => result.status === 'failed')) process.exitCode = 1;
 }
@@ -1488,13 +1497,10 @@ export const pluginCommand = defineCliCommand({
     const dryRun = args['dry-run'] === true;
     const force = args.force === true;
     const noAuth = args['no-auth'] === true;
+    const jsonOutput = shouldOutputJson(flags);
     const detections = new Map<PluginId, Detection>(
       TARGETS.map((target) => [target.id, detectTarget(target)]),
     );
-
-    if (flags.json && !dryRun) {
-      throw new Error('--json is only supported with --dry-run for plugin');
-    }
 
     let selectedIds = parseOnly(args.only);
     if (args.all === true) {
@@ -1558,7 +1564,7 @@ export const pluginCommand = defineCliCommand({
       }
     }
 
-    if (flags.json) {
+    if (jsonOutput) {
       process.stdout.write(`${JSON.stringify({ results }, null, 2)}\n`);
     } else {
       printHumanSummary(results, dryRun, noAuth);
@@ -1570,7 +1576,7 @@ export const pluginCommand = defineCliCommand({
     const authFailed = await authorizePlugins(oauthTargets, {
       dryRun,
       noAuth,
-      json: flags.json === true,
+      json: jsonOutput,
     });
 
     if (results.some((result) => result.status === 'failed') || authFailed) {

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -138,7 +138,7 @@ function printSupermemoryBanner(): void {
         rendered += ' ';
       }
     }
-    process.stderr.write(rendered + '\n');
+    process.stderr.write(`${rendered}\n`);
   }
 
   const label = chalk.hex('#18BFFF')('>') + chalk.hex('#1775EF').bold(' PLUGINS');
@@ -245,7 +245,7 @@ async function arrowSelect<T extends string>(opts: {
       }
       lines.push(`${chalk.cyan(TUI_BAR)}`);
       lines.push(`${chalk.cyan(TUI_BOTTOM)} ${chalk.dim(opts.footer ?? 'Up/Down move, Enter confirm, Esc cancel')}`);
-      process.stderr.write(lines.join('\n') + '\n');
+      process.stderr.write(`${lines.join('\n')}\n`);
       return lines.length;
     },
     (key) => {
@@ -293,7 +293,7 @@ async function arrowMultiselect<T extends string>(opts: {
       if (error) lines.push(`${chalk.yellow(TUI_BAR)} ${chalk.yellow(error)}`);
       lines.push(`${chalk.cyan(TUI_BAR)}`);
       lines.push(`${chalk.cyan(TUI_BOTTOM)} ${chalk.dim(opts.footer ?? 'Up/Down move, Space select, Enter confirm, Esc back')}`);
-      process.stderr.write(lines.join('\n') + '\n');
+      process.stderr.write(`${lines.join('\n')}\n`);
       return lines.length;
     },
     (key) => {
@@ -709,7 +709,6 @@ function startPluginAuthCallbackServer(clients: PluginClientId[]): Promise<{
       rejectCallback = reject;
     });
 
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const clearAuthTimeout = () => {
       if (timeoutId) clearTimeout(timeoutId);
     };
@@ -787,7 +786,7 @@ function startPluginAuthCallbackServer(clients: PluginClientId[]): Promise<{
       rejectServer(error);
     });
 
-    timeoutId = setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       rejectCallback(new Error('Authentication timed out'));
       server.close();
     }, 10 * 60_000);
@@ -938,7 +937,7 @@ async function authorizePlugins(
         error instanceof Error ? error.message : String(error)
       }\n\n`,
     );
-    process.stdout.write(`  Rerun the command to open a fresh OAuth callback and upgrade link.\n\n`);
+    process.stdout.write("  Rerun the command to open a fresh OAuth callback and upgrade link.\n\n");
     return true;
   } finally {
     callback.close();
@@ -1187,7 +1186,7 @@ async function chooseInstalledTargetIds(action: 'connect' | 'remove'): Promise<P
     options: targets.map((target) => ({
       value: target.id,
       label: target.label,
-      hint: states.get(target.id)?.version ? 'v' + states.get(target.id)?.version : 'installed',
+      hint: states.get(target.id)?.version ? `v${states.get(target.id)?.version}` : 'installed',
     })),
   });
 
@@ -1218,9 +1217,7 @@ export async function loginInstalledPlugins(options: {
   const missing = selectedIds.filter((id) => !targets.some((target) => target.id === id));
   if (missing.length > 0) {
     throw new Error(
-      'Not installed: ' +
-        missing.map((id) => TARGETS.find((target) => target.id === id)?.label ?? id).join(', ') +
-        '. Run supermemory plugin first.',
+      `Not installed: ${missing.map((id) => TARGETS.find((target) => target.id === id)?.label ?? id).join(', ')}. Run supermemory plugin first.`,
     );
   }
 
@@ -1286,7 +1283,7 @@ async function uninstallTarget(target: PluginTarget, dryRun: boolean): Promise<U
       if (!dryRun) log = await runProcess('claude', args);
     }
     if (target.id === 'cursor') {
-      steps.push('remove ' + CURSOR_PLUGIN_TARGET);
+      steps.push(`remove ${CURSOR_PLUGIN_TARGET}`);
       if (!dryRun) rmSync(CURSOR_PLUGIN_TARGET, { recursive: true, force: true });
     }
     if (target.id === 'opencode') {
@@ -1322,17 +1319,17 @@ async function uninstallTarget(target: PluginTarget, dryRun: boolean): Promise<U
 
 function printUninstallSummary(results: UninstallResult[], dryRun: boolean): void {
   const title = dryRun ? 'Supermemory uninstall plan' : 'Supermemory uninstall summary';
-  process.stdout.write('\n' + chalk.bold(title) + '\n\n');
+  process.stdout.write(`\n${chalk.bold(title)}\n\n`);
   for (const result of results) {
     const icon =
       result.status === 'removed' ? chalk.green('[ok]')
       : result.status === 'planned' ? chalk.cyan('[plan]')
       : result.status === 'skipped' ? chalk.yellow('[skip]')
       : chalk.red('[fail]');
-    process.stdout.write(icon + ' ' + chalk.bold(result.label) + ': ' + result.message + '\n');
-    for (const step of result.steps) process.stdout.write('  ' + chalk.dim(step) + '\n');
+    process.stdout.write(`${icon} ${chalk.bold(result.label)}: ${result.message}\n`);
+    for (const step of result.steps) process.stdout.write(`  ${chalk.dim(step)}\n`);
     if (result.log && result.status === 'failed') {
-      process.stdout.write('  ' + chalk.dim(result.log) + '\n');
+      process.stdout.write(`  ${chalk.dim(result.log)}\n`);
     }
     process.stdout.write('\n');
   }
@@ -1354,7 +1351,7 @@ async function handlePluginUninstall(
     selectedIds = await chooseInstalledTargetIds('remove');
   }
   if (selectedIds.length === 0) {
-    process.stdout.write('\n' + chalk.yellow('[skip]') + ' No installed Supermemory plugins found.\n\n');
+    process.stdout.write(`\n${chalk.yellow('[skip]')} No installed Supermemory plugins found.\n\n`);
     return;
   }
 
@@ -1375,7 +1372,7 @@ async function handlePluginUninstall(
     results.push(await uninstallTarget(target, dryRun));
   }
 
-  if (flags.json) process.stdout.write(JSON.stringify({ results }, null, 2) + '\n');
+  if (flags.json) process.stdout.write(`${JSON.stringify({ results }, null, 2)}\n`);
   else printUninstallSummary(results, dryRun);
   if (results.some((result) => result.status === 'failed')) process.exitCode = 1;
 }
@@ -1415,7 +1412,7 @@ export const uninstallCommand = defineCliCommand({
       selectedIds = await chooseInstalledTargetIds('remove');
     }
     if (selectedIds.length === 0) {
-      process.stdout.write('\n' + chalk.yellow('[skip]') + ' No installed Supermemory plugins found.\n\n');
+      process.stdout.write(`\n${chalk.yellow('[skip]')} No installed Supermemory plugins found.\n\n`);
       return;
     }
 
@@ -1436,7 +1433,7 @@ export const uninstallCommand = defineCliCommand({
       results.push(await uninstallTarget(target, dryRun));
     }
 
-    if (flags.json) process.stdout.write(JSON.stringify({ results }, null, 2) + '\n');
+    if (flags.json) process.stdout.write(`${JSON.stringify({ results }, null, 2)}\n`);
     else printUninstallSummary(results, dryRun);
     if (results.some((result) => result.status === 'failed')) process.exitCode = 1;
   },
@@ -1551,7 +1548,7 @@ export const pluginCommand = defineCliCommand({
           status: 'current',
           message:
             installed.version && latestVersion ?
-              'already up to date (v' + installed.version + ')' + (dryRun || noAuth ? '' : '; continuing to OAuth')
+              `already up to date (v${installed.version})${dryRun || noAuth ? '' : '; continuing to OAuth'}`
             : 'already installed; version could not be verified, use --force to reinstall',
           steps: [],
         });

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -1532,7 +1532,10 @@ export const pluginCommand = defineCliCommand({
       const shouldInstall =
         force ||
         !installed.installed ||
-        Boolean(installed.version && latestVersion && compareVersions(installed.version, latestVersion) < 0);
+        Boolean(
+          latestVersion &&
+            (!installed.version || compareVersions(installed.version, latestVersion) < 0),
+        );
 
       if (!shouldInstall) {
         results.push({

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -11,6 +11,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { clearScreenDown, cursorTo, emitKeypressEvents, moveCursor } from 'node:readline';
 import type { AddressInfo } from 'node:net';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, extname, join } from 'node:path';
@@ -19,13 +20,22 @@ import chalk from 'chalk';
 import { getDeviceInfo, openBrowser } from '../lib/browser.js';
 import { defineCliCommand } from '../lib/command.js';
 import { resolveConfig } from '../lib/config.js';
+import {
+  compareVersions,
+  CURSOR_PLUGIN_TARGET,
+  detectInstalledPlugin,
+  forgetPluginVersion,
+  getLatestPluginVersion,
+  type PluginId,
+  recordPluginVersion,
+  removeOpenCodePlugin,
+} from './plugin-lifecycle.js';
 import { isInputInteractive, isInteractive } from '../lib/output.js';
 
-type PluginId = 'claude' | 'cursor' | 'opencode' | 'codex';
 type PluginClientId = 'claude_code' | 'cursor' | 'opencode' | 'codex';
 type InstallMode = 'all' | 'custom';
 
-type InstallStatus = 'planned' | 'installed' | 'skipped' | 'failed';
+type InstallStatus = 'planned' | 'installed' | 'current' | 'skipped' | 'failed';
 
 interface PluginTarget {
   id: PluginId;
@@ -62,6 +72,236 @@ interface PluginAuthResult {
   upgradeUrl?: string;
 }
 
+interface UninstallResult {
+  id: PluginId;
+  label: string;
+  status: 'planned' | 'removed' | 'skipped' | 'failed';
+  message: string;
+  steps: string[];
+  log?: string;
+}
+
+const PROMPT_CANCELLED = Symbol('prompt_cancelled');
+
+type PromptCancel = typeof PROMPT_CANCELLED;
+
+interface ArrowPromptOption<T extends string> {
+  value: T;
+  label: string;
+  hint?: string;
+  disabled?: boolean;
+}
+
+const SUPERMEMORY_ART = [
+  '  ____  _   _ ____  _____ ____  __  __  ___  ____  __   __',
+  ' / ___|| | | |  _ \\| ____|  _ \\|  \\/  |/ _ \\|  _ \\ \\ \\ / /',
+  ' \\___ \\| | | | |_) |  _| | |_) | |\\/| | | | | |_) | \\ V /',
+  '  ___) | |_| |  _ <| |___|  _ <| |  | | |_| |  _ <   | |',
+  ' |____/ \\___/|_| \\_\\_____|_| \\_\\_|  |_|\\___/|_| \\_\\  |_|',
+];
+
+const BANNER_SHADES = ['#60A5FA', '#3B82F6', '#2563EB', '#1D4ED8', '#163B8C'];
+
+function printSupermemoryBanner(): void {
+  process.stderr.write('\n');
+  for (let rowIndex = 0; rowIndex < SUPERMEMORY_ART.length; rowIndex++) {
+    const line = SUPERMEMORY_ART[rowIndex] ?? '';
+    let rendered = '  ';
+    for (let column = 0; column < line.length; column++) {
+      const character = line[column] ?? ' ';
+      if (character === ' ') {
+        rendered += character;
+        continue;
+      }
+      const shade = BANNER_SHADES[(rowIndex + Math.floor(column / 12)) % BANNER_SHADES.length] ?? '#2563EB';
+      rendered += chalk.hex(shade)(character);
+    }
+    process.stderr.write(rendered + '\n');
+  }
+  process.stderr.write(`  ${chalk.hex('#60A5FA').bold('Supermemory')} ${chalk.dim('plugin installer')}\n\n`);
+}
+function clearRenderedPrompt(renderedLines: number): void {
+  if (renderedLines <= 0) return;
+  moveCursor(process.stderr, 0, -renderedLines);
+  cursorTo(process.stderr, 0);
+  clearScreenDown(process.stderr);
+}
+
+const TUI_TOP = '\u250C';
+const TUI_BAR = '\u2502';
+const TUI_BOTTOM = '\u2514';
+const TUI_SUBMIT = '\u25C7';
+const TUI_POINTER = '\u276F';
+const TUI_RADIO_ACTIVE = '\u25CF';
+const TUI_RADIO_INACTIVE = '\u25CB';
+
+function finishArrowPrompt(message: string, value: string): void {
+  process.stderr.write(`${chalk.cyan(TUI_SUBMIT)}  ${message}\n`);
+  process.stderr.write(`${chalk.cyan(TUI_BAR)}  ${value}\n`);
+  process.stderr.write(`${chalk.cyan(TUI_BAR)}\n`);
+}
+
+function withRawKeypress<T>(render: () => number, onKey: (key: { name?: string; ctrl?: boolean }) => T | undefined): Promise<T> {
+  const input = process.stdin as NodeJS.ReadStream & { setRawMode?: (mode: boolean) => void };
+  const hadRawMode = Boolean(input.isRaw);
+  let renderedLines = 0;
+
+  return new Promise<T>((resolve) => {
+    const cleanup = (result: T) => {
+      input.off('keypress', handler);
+      if (input.setRawMode && !hadRawMode) input.setRawMode(false);
+      process.stderr.write('\u001B[?25h');
+      resolve(result);
+    };
+
+    const rerender = () => {
+      clearRenderedPrompt(renderedLines);
+      renderedLines = render();
+    };
+
+    const handler = (_input: string, key: { name?: string; ctrl?: boolean }) => {
+      if (key.ctrl && key.name === 'c') {
+        clearRenderedPrompt(renderedLines);
+        cleanup(PROMPT_CANCELLED as T);
+        return;
+      }
+      const result = onKey(key);
+      if (result !== undefined) {
+        clearRenderedPrompt(renderedLines);
+        cleanup(result);
+        return;
+      }
+      rerender();
+    };
+
+    emitKeypressEvents(input);
+    if (input.setRawMode) input.setRawMode(true);
+    input.on('keypress', handler);
+    process.stderr.write('\u001B[?25l');
+    rerender();
+  });
+}
+
+function nextEnabledIndex<T extends string>(
+  options: ArrowPromptOption<T>[],
+  current: number,
+  direction: 1 | -1,
+): number {
+  if (options.length === 0) return 0;
+  let next = current;
+  for (let i = 0; i < options.length; i++) {
+    next = (next + direction + options.length) % options.length;
+    if (!options[next]?.disabled) return next;
+  }
+  return current;
+}
+
+async function arrowSelect<T extends string>(opts: {
+  message: string;
+  options: ArrowPromptOption<T>[];
+  footer?: string;
+}): Promise<T | PromptCancel> {
+  let active = Math.max(
+    0,
+    opts.options.findIndex((option) => !option.disabled),
+  );
+
+  const result = await withRawKeypress<T | PromptCancel>(
+    () => {
+      const lines = [`${chalk.cyan(TUI_TOP)} ${chalk.bold(opts.message)}`, `${chalk.cyan(TUI_BAR)}`];
+      for (let i = 0; i < opts.options.length; i++) {
+        const option = opts.options[i];
+        if (!option) continue;
+        const pointer = i === active ? chalk.cyan(TUI_POINTER) : ' ';
+        const marker = i === active ? chalk.cyan(TUI_RADIO_ACTIVE) : chalk.dim(TUI_RADIO_INACTIVE);
+        const label = option.disabled ? chalk.dim(option.label) : option.label;
+        const hint = option.hint ? ` ${chalk.dim(option.hint)}` : '';
+        lines.push(`${chalk.cyan(TUI_BAR)} ${pointer} ${marker} ${label}${hint}`);
+      }
+      lines.push(`${chalk.cyan(TUI_BAR)}`);
+      lines.push(`${chalk.cyan(TUI_BOTTOM)} ${chalk.dim(opts.footer ?? 'Up/Down move, Enter confirm, Esc cancel')}`);
+      process.stderr.write(lines.join('\n') + '\n');
+      return lines.length;
+    },
+    (key) => {
+      if (key.name === 'escape') return PROMPT_CANCELLED;
+      if (key.name === 'up' || key.name === 'k') active = nextEnabledIndex(opts.options, active, -1);
+      if (key.name === 'down' || key.name === 'j') active = nextEnabledIndex(opts.options, active, 1);
+      if (key.name === 'return' || key.name === 'enter') return opts.options[active]?.value;
+      return undefined;
+    },
+  );
+
+  if (result !== PROMPT_CANCELLED) {
+    const label = opts.options.find((option) => option.value === result)?.label ?? String(result);
+    finishArrowPrompt(opts.message, label);
+  }
+  return result;
+}
+
+async function arrowMultiselect<T extends string>(opts: {
+  message: string;
+  options: ArrowPromptOption<T>[];
+  initialValues?: T[];
+  footer?: string;
+}): Promise<T[] | PromptCancel> {
+  let active = Math.max(
+    0,
+    opts.options.findIndex((option) => !option.disabled),
+  );
+  let error = '';
+  const selected = new Set<T>(opts.initialValues ?? []);
+
+  const result = await withRawKeypress<T[] | PromptCancel>(
+    () => {
+      const lines = [`${chalk.cyan(TUI_TOP)} ${chalk.bold(opts.message)}`, `${chalk.cyan(TUI_BAR)}`];
+      for (let i = 0; i < opts.options.length; i++) {
+        const option = opts.options[i];
+        if (!option) continue;
+        const checked = selected.has(option.value);
+        const pointer = i === active ? chalk.cyan(TUI_POINTER) : ' ';
+        const marker = checked ? chalk.green(TUI_RADIO_ACTIVE) : chalk.dim(TUI_RADIO_INACTIVE);
+        const label = option.disabled ? chalk.dim(option.label) : option.label;
+        const hint = option.hint ? ` ${chalk.dim(option.hint)}` : '';
+        lines.push(`${chalk.cyan(TUI_BAR)} ${pointer} ${marker} ${label}${hint}`);
+      }
+      if (error) lines.push(`${chalk.yellow(TUI_BAR)} ${chalk.yellow(error)}`);
+      lines.push(`${chalk.cyan(TUI_BAR)}`);
+      lines.push(`${chalk.cyan(TUI_BOTTOM)} ${chalk.dim(opts.footer ?? 'Up/Down move, Space select, Enter confirm, Esc back')}`);
+      process.stderr.write(lines.join('\n') + '\n');
+      return lines.length;
+    },
+    (key) => {
+      if (key.name === 'escape') return PROMPT_CANCELLED;
+      if (key.name === 'up' || key.name === 'k') active = nextEnabledIndex(opts.options, active, -1);
+      if (key.name === 'down' || key.name === 'j') active = nextEnabledIndex(opts.options, active, 1);
+      if (key.name === 'space') {
+        const option = opts.options[active];
+        if (!option || option.disabled) return undefined;
+        error = '';
+        if (selected.has(option.value)) selected.delete(option.value);
+        else selected.add(option.value);
+      }
+      if (key.name === 'return' || key.name === 'enter') {
+        if (selected.size === 0) {
+          error = 'Select at least one integration.';
+          return undefined;
+        }
+        return [...selected];
+      }
+      return undefined;
+    },
+  );
+
+  if (result !== PROMPT_CANCELLED) {
+    const labels = opts.options
+      .filter((option) => result.includes(option.value))
+      .map((option) => option.label)
+      .join(', ');
+    finishArrowPrompt(opts.message, labels);
+  }
+  return result;
+}
 class CommandError extends Error {
   constructor(
     message: string,
@@ -71,7 +311,6 @@ class CommandError extends Error {
   }
 }
 
-const CURSOR_PLUGIN_TARGET = join(homedir(), '.cursor', 'plugins', 'local', 'cursor-supermemory');
 const PLUGIN_BILLING_URL = 'https://app.supermemory.ai/?settings=billing';
 
 const PLUGIN_AUTH_CLIENTS: Record<PluginId, PluginClientId> = {
@@ -246,22 +485,23 @@ function formatDetectionSource(detection: Detection): string {
 }
 
 function printDetectionSummary(detections: Map<PluginId, Detection>) {
-  process.stderr.write(`  ${chalk.bold('Detected integrations:')}\n`);
+  process.stderr.write(`${chalk.cyan(TUI_TOP)} ${chalk.bold('Supermemory plugin')}\n`);
+  process.stderr.write(`${chalk.cyan(TUI_BAR)} ${chalk.bold('Detected integrations')}\n`);
   for (const target of TARGETS) {
     const detection = detections.get(target.id);
     if (detection?.available) {
       process.stderr.write(
-        `    ${chalk.green('[ready]')} ${chalk.bold(target.label)} ${chalk.dim(
+        `${chalk.cyan(TUI_BAR)}   ${chalk.green('[ready]')} ${chalk.bold(target.label)} ${chalk.dim(
           formatDetectionSource(detection),
         )}\n`,
       );
     } else {
       process.stderr.write(
-        `    ${chalk.red('[missing]')} ${chalk.bold(target.label)} ${chalk.dim('not detected')}\n`,
+        `${chalk.cyan(TUI_BAR)}   ${chalk.red('[missing]')} ${chalk.bold(target.label)} ${chalk.dim('not detected')}\n`,
       );
     }
   }
-  process.stderr.write('\n');
+  process.stderr.write(`${chalk.cyan(TUI_BOTTOM)} ${chalk.dim('scripts can use supermemory plugin --all')}\n\n`);
 }
 
 function parseOnly(value: unknown): PluginId[] {
@@ -559,8 +799,8 @@ function printPluginAuthSummary(results: PluginAuthResult[]): void {
   process.stdout.write('\n');
 }
 
-function printPluginAuthStart(installed: InstallResult[]): void {
-  const labels = installed.map((result) => result.label).join(', ');
+function printPluginAuthStart(targets: Array<{ id: PluginId; label: string }>): void {
+  const labels = targets.map((target) => target.label).join(', ');
   process.stdout.write(`\n${chalk.cyan('┌')} ${chalk.bold('Supermemory OAuth')}\n`);
   process.stdout.write(`${chalk.cyan('│')} ${chalk.bold('One approval')} connects ${chalk.bold(labels)}.\n`);
   process.stdout.write(
@@ -594,22 +834,19 @@ function getPluginAuthBaseUrl(consoleUrl: string): string {
   return consoleUrl;
 }
 
-async function authorizeInstalledPlugins(
-  results: InstallResult[],
-  options: { dryRun: boolean; noAuth: boolean; json: boolean },
+async function authorizePlugins(
+  targets: Array<{ id: PluginId; label: string }>,
+  options: { dryRun?: boolean; noAuth?: boolean; json?: boolean; noBrowser?: boolean },
 ): Promise<boolean> {
   if (options.dryRun || options.noAuth || options.json || !isInputInteractive()) {
     return false;
   }
 
-  const installed = results.filter(
-    (result): result is InstallResult & { status: 'installed' } => result.status === 'installed',
-  );
-  if (installed.length === 0) return false;
+  if (targets.length === 0) return false;
 
-  printPluginAuthStart(installed);
+  printPluginAuthStart(targets);
 
-  const clients = installed.map((result) => PLUGIN_AUTH_CLIENTS[result.id]);
+  const clients = targets.map((target) => PLUGIN_AUTH_CLIENTS[target.id]);
   const callback = await startPluginAuthCallbackServer(clients);
   const config = resolveConfig();
   const device = getDeviceInfo();
@@ -627,19 +864,23 @@ async function authorizeInstalledPlugins(
   const spinner = isInteractive() ? clack.spinner() : null;
 
   try {
-    spinner?.start('Opening one-click Supermemory OAuth...');
-    try {
-      await openBrowser(authUrl);
-    } catch {
-      spinner?.message('Could not open browser automatically.');
+    if (options.noBrowser) {
       process.stdout.write(`  Open this URL to authorize selected plugins:\n\n  ${chalk.cyan(authUrl)}\n\n`);
+    } else {
+      spinner?.start('Opening one-click Supermemory OAuth...');
+      try {
+        await openBrowser(authUrl);
+      } catch {
+        spinner?.message('Could not open browser automatically.');
+        process.stdout.write(`  Open this URL to authorize selected plugins:\n\n  ${chalk.cyan(authUrl)}\n\n`);
+      }
     }
 
     const { keys, errors } = await callback.waitForCallback();
     spinner?.stop('OAuth complete');
 
     const authResults: PluginAuthResult[] = [];
-    for (const result of installed) {
+    for (const result of targets) {
       const client = PLUGIN_AUTH_CLIENTS[result.id];
       const apiKey = keys[client];
       if (apiKey?.startsWith('sm_')) {
@@ -807,6 +1048,7 @@ function printHumanSummary(results: InstallResult[], dryRun: boolean, noAuth: bo
     const icon =
       result.status === 'installed' ? chalk.green('[ok]')
       : result.status === 'planned' ? chalk.cyan('[plan]')
+      : result.status === 'current' ? chalk.green('[ok]')
       : result.status === 'skipped' ? chalk.yellow('[skip]')
       : chalk.red('[fail]');
 
@@ -824,11 +1066,14 @@ function printHumanSummary(results: InstallResult[], dryRun: boolean, noAuth: bo
   }
 
   const authTargets = results.filter(
-    (r) => r.status !== 'skipped' && ['claude', 'cursor', 'opencode', 'codex'].includes(r.id),
+    (r) =>
+      (r.status === 'installed' || r.status === 'current') &&
+      ['claude', 'cursor', 'opencode', 'codex'].includes(r.id),
   );
   if (authTargets.length > 0 && !dryRun && !noAuth && isInputInteractive()) {
+    const authLabels = authTargets.map((target) => target.label).join(', ');
     process.stdout.write(
-      `  ${chalk.dim('Auth:')} one browser approval will connect successfully installed plugins.\n\n`,
+      `  ${chalk.dim('OAuth:')} install is ready; continuing to browser approval for ${authLabels}.\n\n`,
     );
   }
   if (authTargets.length > 0 && noAuth) {
@@ -848,20 +1093,15 @@ function getReadyTargetIds(detections: Map<PluginId, Detection>): PluginId[] {
 }
 
 async function chooseTargetsInteractively(detections: Map<PluginId, Detection>): Promise<PluginId[]> {
-  process.stderr.write('\n');
+  printSupermemoryBanner();
   printDetectionSummary(detections);
-  process.stderr.write(`  ${chalk.dim('tip: use Up/Down to move, Enter to confirm')}\n`);
-  process.stderr.write(
-    `  ${chalk.dim('tip: custom selection uses Space to toggle, Esc to return to install mode')}\n`,
-  );
-  process.stderr.write(`  ${chalk.dim('tip: scripts can use')} supermemory plugin --all\n\n`);
 
   const readyIds = getReadyTargetIds(detections);
-  const modeOptions: { value: InstallMode; label: string; hint?: string }[] = [
+  const modeOptions: ArrowPromptOption<InstallMode>[] = [
     {
       value: 'custom',
       label: 'Custom selection',
-      hint: 'pick plugins with Space',
+      hint: 'pick integrations with Space',
     },
   ];
 
@@ -873,37 +1113,310 @@ async function chooseTargetsInteractively(detections: Map<PluginId, Detection>):
     });
   }
 
-  const mode = await clack.select({
-    message: 'Install mode',
-    options: modeOptions,
+  while (true) {
+    const mode = await arrowSelect({
+      message: 'Which integrations should Supermemory install?',
+      options: modeOptions,
+    });
+
+    if (mode === PROMPT_CANCELLED) {
+      clack.cancel('Install cancelled.');
+      process.exit(0);
+    }
+
+    if (mode === 'all') return readyIds;
+
+    const selected = await arrowMultiselect({
+      message: 'Select integrations',
+      footer: 'Up/Down move, Space select, Enter confirm, Esc return to install mode',
+      options: TARGETS.map((target) => {
+        const detection = detections.get(target.id);
+        const display = formatOptionDisplay(target, detection);
+        return {
+          value: target.id,
+          label: display.label,
+          hint: display.hint,
+          disabled: !detection?.available,
+        };
+      }),
+      initialValues: readyIds.length === 1 ? readyIds : [],
+    });
+
+    if (selected === PROMPT_CANCELLED) continue;
+
+    return selected.filter((id): id is PluginId => id in ALIASES);
+  }
+}
+function installedTargets(): PluginTarget[] {
+  return TARGETS.filter((target) => detectInstalledPlugin(target.id).installed);
+}
+
+async function chooseInstalledTargetIds(action: 'connect' | 'remove'): Promise<PluginId[]> {
+  const targets = installedTargets();
+  const states = new Map(targets.map((target) => [target.id, detectInstalledPlugin(target.id)]));
+  if (targets.length === 0) return [];
+
+  printSupermemoryBanner();
+  const selected = await arrowMultiselect({
+    message: action === 'connect' ? 'Select plugins to connect' : 'Select plugins to remove',
+    options: targets.map((target) => ({
+      value: target.id,
+      label: target.label,
+      hint: states.get(target.id)?.version ? 'v' + states.get(target.id)?.version : 'installed',
+    })),
   });
 
-  if (clack.isCancel(mode)) {
-    clack.cancel('Install cancelled.');
+  if (selected === PROMPT_CANCELLED) {
+    clack.cancel(action === 'connect' ? 'Login cancelled.' : 'Uninstall cancelled.');
     process.exit(0);
   }
+  return selected.filter((id): id is PluginId => TARGETS.some((target) => target.id === id));
+}
 
-  if (mode === 'all') return readyIds;
+export async function loginInstalledPlugins(options: {
+  all?: boolean;
+  only?: unknown;
+  noBrowser?: boolean;
+  json?: boolean;
+}): Promise<boolean> {
+  const targets = installedTargets();
+  if (targets.length === 0) return false;
+  if (options.json) throw new Error('--json is not supported for browser OAuth');
 
-  const selected = await clack.multiselect({
-    message: 'Choose integrations to install',
-    required: true,
-    options: TARGETS.map((target) => {
-      const display = formatOptionDisplay(target, detections.get(target.id));
-      return {
-        value: target.id,
-        label: display.label,
-        hint: display.hint,
-      };
-    }),
-  });
-
-  if (clack.isCancel(selected)) {
-    return chooseTargetsInteractively(detections);
+  let selectedIds = parseOnly(options.only);
+  if (options.all) selectedIds = targets.map((target) => target.id);
+  if (selectedIds.length === 0) {
+    if (!isInputInteractive()) return false;
+    selectedIds = await chooseInstalledTargetIds('connect');
   }
 
-  return selected.filter((id): id is PluginId => id in ALIASES);
+  const missing = selectedIds.filter((id) => !targets.some((target) => target.id === id));
+  if (missing.length > 0) {
+    throw new Error(
+      'Not installed: ' +
+        missing.map((id) => TARGETS.find((target) => target.id === id)?.label ?? id).join(', ') +
+        '. Run supermemory plugin first.',
+    );
+  }
+
+  const selected = targets
+    .filter((target) => selectedIds.includes(target.id))
+    .map(({ id, label }) => ({ id, label }));
+  const failed = await authorizePlugins(selected, { noBrowser: options.noBrowser });
+  if (failed) process.exitCode = 1;
+  return true;
 }
+
+async function handlePluginLogin(options: {
+  all: boolean;
+  only: unknown;
+  noBrowser: boolean;
+  json: boolean;
+}): Promise<void> {
+  const handled = await loginInstalledPlugins(options);
+  if (!handled) {
+    throw new Error('No installed Supermemory plugins found. Run supermemory plugin first.');
+  }
+}
+
+export const pluginLoginCommand = defineCliCommand({
+  meta: {
+    name: 'login',
+    description: 'Connect installed Supermemory plugins with browser OAuth',
+  },
+  noSpan: true,
+  args: {
+    all: {
+      type: 'boolean',
+      description: 'Connect every installed Supermemory plugin',
+      default: false,
+    },
+    only: {
+      type: 'string',
+      description: 'Comma-separated targets: claude,cursor,opencode,codex',
+    },
+    browser: {
+      type: 'boolean',
+      description: 'Open the OAuth page in a browser (use --no-browser to show the URL)',
+      default: true,
+    },
+  },
+  async handler({ args, flags }) {
+    await handlePluginLogin({
+      all: args.all === true,
+      only: args.only,
+      noBrowser: args.browser !== true,
+      json: flags.json === true,
+    });
+  },
+});
+
+async function uninstallTarget(target: PluginTarget, dryRun: boolean): Promise<UninstallResult> {
+  const steps: string[] = [];
+  try {
+    let log: string | undefined;
+    if (target.id === 'claude') {
+      const args = ['plugin', 'uninstall', 'supermemory@supermemory-plugins', '--scope', 'user'];
+      steps.push(formatStep('claude', args));
+      if (!dryRun) log = await runProcess('claude', args);
+    }
+    if (target.id === 'cursor') {
+      steps.push('remove ' + CURSOR_PLUGIN_TARGET);
+      if (!dryRun) rmSync(CURSOR_PLUGIN_TARGET, { recursive: true, force: true });
+    }
+    if (target.id === 'opencode') {
+      steps.push('remove opencode-supermemory from OpenCode config and generated commands');
+      if (!dryRun) steps.splice(0, steps.length, ...removeOpenCodePlugin());
+    }
+    if (target.id === 'codex') {
+      const args = ['-y', 'codex-supermemory@latest', 'uninstall'];
+      steps.push(formatStep('npx', args));
+      if (!dryRun) log = await runProcess('npx', args);
+    }
+
+    if (!dryRun) forgetPluginVersion(target.id);
+    return {
+      id: target.id,
+      label: target.label,
+      status: dryRun ? 'planned' : 'removed',
+      message: dryRun ? 'would be removed' : 'removed; credentials and memories were kept',
+      steps,
+      log,
+    };
+  } catch (error) {
+    return {
+      id: target.id,
+      label: target.label,
+      status: 'failed',
+      message: error instanceof Error ? error.message : String(error),
+      steps,
+      log: error instanceof CommandError ? error.log : undefined,
+    };
+  }
+}
+
+function printUninstallSummary(results: UninstallResult[], dryRun: boolean): void {
+  const title = dryRun ? 'Supermemory uninstall plan' : 'Supermemory uninstall summary';
+  process.stdout.write('\n' + chalk.bold(title) + '\n\n');
+  for (const result of results) {
+    const icon =
+      result.status === 'removed' ? chalk.green('[ok]')
+      : result.status === 'planned' ? chalk.cyan('[plan]')
+      : result.status === 'skipped' ? chalk.yellow('[skip]')
+      : chalk.red('[fail]');
+    process.stdout.write(icon + ' ' + chalk.bold(result.label) + ': ' + result.message + '\n');
+    for (const step of result.steps) process.stdout.write('  ' + chalk.dim(step) + '\n');
+    if (result.log && result.status === 'failed') {
+      process.stdout.write('  ' + chalk.dim(result.log) + '\n');
+    }
+    process.stdout.write('\n');
+  }
+}
+
+async function handlePluginUninstall(
+  args: Record<string, unknown>,
+  flags: { json?: boolean },
+): Promise<void> {
+  const dryRun = args['dry-run'] === true;
+  const installed = installedTargets();
+  let selectedIds = parseOnly(args.only);
+  if (args.all === true) selectedIds = installed.map((target) => target.id);
+
+  if (selectedIds.length === 0 && args.all !== true) {
+    if (!isInputInteractive() || flags.json) {
+      throw new Error('Choose targets with --all or --only claude,cursor,opencode,codex');
+    }
+    selectedIds = await chooseInstalledTargetIds('remove');
+  }
+  if (selectedIds.length === 0) {
+    process.stdout.write('\n' + chalk.yellow('[skip]') + ' No installed Supermemory plugins found.\n\n');
+    return;
+  }
+
+  const results: UninstallResult[] = [];
+  for (const id of selectedIds) {
+    const target = TARGETS.find((candidate) => candidate.id === id);
+    if (!target) continue;
+    if (!installed.some((candidate) => candidate.id === id)) {
+      results.push({
+        id,
+        label: target.label,
+        status: 'skipped',
+        message: 'not installed',
+        steps: [],
+      });
+      continue;
+    }
+    results.push(await uninstallTarget(target, dryRun));
+  }
+
+  if (flags.json) process.stdout.write(JSON.stringify({ results }, null, 2) + '\n');
+  else printUninstallSummary(results, dryRun);
+  if (results.some((result) => result.status === 'failed')) process.exitCode = 1;
+}
+
+export const uninstallCommand = defineCliCommand({
+  meta: {
+    name: 'uninstall',
+    description: 'Remove selected Supermemory plugin integrations',
+  },
+  noSpan: true,
+  args: {
+    all: {
+      type: 'boolean',
+      description: 'Remove every installed Supermemory plugin',
+      default: false,
+    },
+    only: {
+      type: 'string',
+      description: 'Comma-separated targets: claude,cursor,opencode,codex',
+    },
+    'dry-run': {
+      type: 'boolean',
+      description: 'Show what would be removed without changing anything',
+      default: false,
+    },
+  },
+  async handler({ args, flags }) {
+    const dryRun = args['dry-run'] === true;
+    const installed = installedTargets();
+    let selectedIds = parseOnly(args.only);
+    if (args.all === true) selectedIds = installed.map((target) => target.id);
+
+    if (selectedIds.length === 0 && args.all !== true) {
+      if (!isInputInteractive() || flags.json) {
+        throw new Error('Choose targets with --all or --only claude,cursor,opencode,codex');
+      }
+      selectedIds = await chooseInstalledTargetIds('remove');
+    }
+    if (selectedIds.length === 0) {
+      process.stdout.write('\n' + chalk.yellow('[skip]') + ' No installed Supermemory plugins found.\n\n');
+      return;
+    }
+
+    const results: UninstallResult[] = [];
+    for (const id of selectedIds) {
+      const target = TARGETS.find((candidate) => candidate.id === id);
+      if (!target) continue;
+      if (!installed.some((candidate) => candidate.id === id)) {
+        results.push({
+          id,
+          label: target.label,
+          status: 'skipped',
+          message: 'not installed',
+          steps: [],
+        });
+        continue;
+      }
+      results.push(await uninstallTarget(target, dryRun));
+    }
+
+    if (flags.json) process.stdout.write(JSON.stringify({ results }, null, 2) + '\n');
+    else printUninstallSummary(results, dryRun);
+    if (results.some((result) => result.status === 'failed')) process.exitCode = 1;
+  },
+});
+
 
 export const pluginCommand = defineCliCommand({
   meta: {
@@ -937,7 +1450,22 @@ export const pluginCommand = defineCliCommand({
       default: false,
     },
   },
-  async handler({ args, flags }) {
+  async handler({ args, flags, rawArgs }) {
+    const action = rawArgs.find((arg) => !arg.startsWith('-'));
+    if (action === 'login') {
+      await handlePluginLogin({
+        all: args.all === true,
+        only: args.only,
+        noBrowser: rawArgs.includes('--no-browser'),
+        json: flags.json === true,
+      });
+      return;
+    }
+    if (action === 'uninstall') {
+      await handlePluginUninstall(args, flags);
+      return;
+    }
+
     const dryRun = args['dry-run'] === true;
     const force = args.force === true;
     const noAuth = args['no-auth'] === true;
@@ -980,7 +1508,38 @@ export const pluginCommand = defineCliCommand({
         continue;
       }
 
-      results.push(await installTarget(target, dryRun));
+      const installed = detectInstalledPlugin(id);
+      const latestVersion = await getLatestPluginVersion(id);
+      const shouldInstall =
+        force ||
+        !installed.installed ||
+        Boolean(
+          installed.version &&
+            latestVersion &&
+            compareVersions(installed.version, latestVersion) < 0,
+        );
+
+      if (!shouldInstall) {
+        results.push({
+          id,
+          label: target.label,
+          status: 'current',
+          message:
+            installed.version && latestVersion ?
+              'already up to date (v' + installed.version + ')' + (dryRun || noAuth ? '' : '; continuing to OAuth')
+            : 'already installed; version could not be verified, use --force to reinstall',
+          steps: [],
+        });
+        continue;
+      }
+
+      const result = await installTarget(target, dryRun);
+      results.push(result);
+      if (!dryRun && result.status === 'installed') {
+        const detectedVersion =
+          latestVersion ?? detectInstalledPlugin(id).version ?? installed.version;
+        if (detectedVersion) recordPluginVersion(id, detectedVersion);
+      }
     }
 
     if (flags.json) {
@@ -989,7 +1548,10 @@ export const pluginCommand = defineCliCommand({
       printHumanSummary(results, dryRun, noAuth);
     }
 
-    const authFailed = await authorizeInstalledPlugins(results, {
+    const oauthTargets = results
+      .filter((result) => result.status === 'installed' || result.status === 'current')
+      .map(({ id, label }) => ({ id, label }));
+    const authFailed = await authorizePlugins(oauthTargets, {
       dryRun,
       noAuth,
       json: flags.json === true,

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -1037,12 +1037,10 @@ async function installTarget(target: PluginTarget, dryRun: boolean): Promise<Ins
         try {
           log = await runProcess('claude', updateMarketplace);
         } catch (error) {
-          if (
-            !(error instanceof CommandError) ||
-            !/not found|does not exist|unknown|not registered/i.test(error.log)
-          ) {
-            throw error;
-          }
+          const isMissingMarketplace =
+            error instanceof CommandError &&
+            /not found|does not exist|unknown|not registered/i.test(error.log ?? '');
+          if (!isMissingMarketplace) throw error;
           log = await runProcess('claude', addMarketplace);
         }
         log = (await runProcess('claude', installPlugin)) ?? log;

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -92,33 +92,70 @@ interface ArrowPromptOption<T extends string> {
   disabled?: boolean;
 }
 
-const SUPERMEMORY_ART = [
-  '  ____  _   _ ____  _____ ____  __  __  ___  ____  __   __',
-  ' / ___|| | | |  _ \\| ____|  _ \\|  \\/  |/ _ \\|  _ \\ \\ \\ / /',
-  ' \\___ \\| | | | |_) |  _| | |_) | |\\/| | | | | |_) | \\ V /',
-  '  ___) | |_| |  _ <| |___|  _ <| |  | | |_| |  _ <   | |',
-  ' |____/ \\___/|_| \\_\\_____|_| \\_\\_|  |_|\\___/|_| \\_\\  |_|',
-];
+const SUPERMEMORY_GLYPHS: Record<string, string[]> = {
+  S: ['11111', '10000', '10000', '11110', '00001', '00001', '11110'],
+  U: ['10001', '10001', '10001', '10001', '10001', '10001', '01110'],
+  P: ['11110', '10001', '10001', '11110', '10000', '10000', '10000'],
+  E: ['11111', '10000', '10000', '11110', '10000', '10000', '11111'],
+  R: ['11110', '10001', '10001', '11110', '10100', '10010', '10001'],
+  M: ['10001', '11011', '10101', '10101', '10001', '10001', '10001'],
+  O: ['01110', '10001', '10001', '10001', '10001', '10001', '01110'],
+  Y: ['10001', '10001', '01010', '00100', '00100', '00100', '00100'],
+};
 
-const BANNER_SHADES = ['#60A5FA', '#3B82F6', '#2563EB', '#1D4ED8', '#163B8C'];
+const SUPERMEMORY_WORD = 'SUPERMEMORY';
+const BANNER_CELL = '\u2588\u2588';
+const BANNER_OUTLINE_CELL = '\u2592\u2592';
+const BANNER_SHADOW_CELL = '\u2591\u2591';
+const BANNER_FILL_COLORS = ['#B9F7FF', '#5BE9FF', '#22C9F4', '#168CF0', '#0B59D0'];
+const BANNER_OUTLINE_COLOR = '#0A86FF';
+const BANNER_SHADOW_COLOR = '#071D82';
 
 function printSupermemoryBanner(): void {
+  const glyphWidth = 5;
+  const glyphGap = 1;
+  const rowCount = 7;
+  const columnCount = SUPERMEMORY_WORD.length * (glyphWidth + glyphGap) - glyphGap;
+  const isFilled = (row: number, column: number): boolean => {
+    if (row < 0 || row >= rowCount || column < 0 || column >= columnCount) return false;
+    const glyphIndex = Math.floor(column / (glyphWidth + glyphGap));
+    const glyphColumn = column % (glyphWidth + glyphGap);
+    if (glyphColumn >= glyphWidth) return false;
+    const glyph = SUPERMEMORY_GLYPHS[SUPERMEMORY_WORD[glyphIndex] ?? ''];
+    return glyph?.[row]?.[glyphColumn] === '1';
+  };
+
   process.stderr.write('\n');
-  for (let rowIndex = 0; rowIndex < SUPERMEMORY_ART.length; rowIndex++) {
-    const line = SUPERMEMORY_ART[rowIndex] ?? '';
+  for (let row = 0; row < rowCount + 1; row++) {
     let rendered = '  ';
-    for (let column = 0; column < line.length; column++) {
-      const character = line[column] ?? ' ';
-      if (character === ' ') {
-        rendered += character;
-        continue;
+    for (let column = -1; column < columnCount + 2; column++) {
+      const main = isFilled(row, column);
+      const outline =
+        !main &&
+        Array.from({ length: 3 }, (_, rowOffset) => rowOffset - 1).some((rowOffset) =>
+          Array.from({ length: 3 }, (_, columnOffset) => columnOffset - 1).some((columnOffset) =>
+            isFilled(row + rowOffset, column + columnOffset),
+          ),
+        );
+      const shadow = !main && !outline && isFilled(row - 1, column - 1);
+
+      if (main) {
+        const color = BANNER_FILL_COLORS[Math.min(row, BANNER_FILL_COLORS.length - 1)] ?? '#22C9F4';
+        rendered += chalk.hex(color)(BANNER_CELL);
+      } else if (outline) {
+        rendered += chalk.hex(BANNER_OUTLINE_COLOR)(BANNER_OUTLINE_CELL);
+      } else if (shadow) {
+        rendered += chalk.hex(BANNER_SHADOW_COLOR)(BANNER_SHADOW_CELL);
+      } else {
+        rendered += '  ';
       }
-      const shade = BANNER_SHADES[(rowIndex + Math.floor(column / 12)) % BANNER_SHADES.length] ?? '#2563EB';
-      rendered += chalk.hex(shade)(character);
     }
     process.stderr.write(rendered + '\n');
   }
-  process.stderr.write(`  ${chalk.hex('#60A5FA').bold('Supermemory')} ${chalk.dim('plugin installer')}\n\n`);
+
+  const label = chalk.hex('#18BFFF')('>') + chalk.hex('#1775EF').bold(' PLUGINS');
+  const labelPadding = Math.max(2, columnCount * 2 - 2 - '> PLUGINS'.length);
+  process.stderr.write(`${' '.repeat(labelPadding)}${label}\n\n`);
 }
 function clearRenderedPrompt(renderedLines: number): void {
   if (renderedLines <= 0) return;

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -873,9 +873,20 @@ function getPluginAuthBaseUrl(consoleUrl: string): string {
 
 async function authorizePlugins(
   targets: Array<{ id: PluginId; label: string }>,
-  options: { dryRun?: boolean; noAuth?: boolean; json?: boolean; noBrowser?: boolean },
+  options: {
+    dryRun?: boolean;
+    noAuth?: boolean;
+    json?: boolean;
+    noBrowser?: boolean;
+    allowNonInteractive?: boolean;
+  },
 ): Promise<boolean> {
-  if (options.dryRun || options.noAuth || options.json || !isInputInteractive()) {
+  if (
+    options.dryRun ||
+    options.noAuth ||
+    options.json ||
+    (!isInputInteractive() && !options.allowNonInteractive)
+  ) {
     return false;
   }
 
@@ -1241,7 +1252,10 @@ export async function loginInstalledPlugins(options: {
   const selected = targets
     .filter((target) => selectedIds.includes(target.id))
     .map(({ id, label }) => ({ id, label }));
-  const failed = await authorizePlugins(selected, { noBrowser: options.noBrowser });
+  const failed = await authorizePlugins(selected, {
+    noBrowser: options.noBrowser,
+    allowNonInteractive: true,
+  });
   if (failed) process.exitCode = 1;
   return true;
 }
@@ -1295,9 +1309,15 @@ async function uninstallTarget(target: PluginTarget, dryRun: boolean): Promise<U
   try {
     let log: string | undefined;
     if (target.id === 'claude') {
-      const args = ['plugin', 'uninstall', 'supermemory@supermemory-plugins', '--scope', 'user'];
-      steps.push(formatStep('claude', args));
-      if (!dryRun) log = await runProcess('claude', args);
+      const scopes = detectInstalledPlugin('claude').scopes ?? ['user'];
+      for (const scope of scopes) {
+        const args = ['plugin', 'uninstall', 'supermemory@supermemory-plugins', '--scope', scope];
+        steps.push(formatStep('claude', args));
+        if (!dryRun) {
+          const scopeLog = await runProcess('claude', args);
+          log = [log, scopeLog].filter(Boolean).join('\n');
+        }
+      }
     }
     if (target.id === 'cursor') {
       steps.push(`remove ${CURSOR_PLUGIN_TARGET}`);
@@ -1368,7 +1388,11 @@ async function handlePluginUninstall(
     selectedIds = await chooseInstalledTargetIds('remove');
   }
   if (selectedIds.length === 0) {
-    process.stdout.write(`\n${chalk.yellow('[skip]')} No installed Supermemory plugins found.\n\n`);
+    if (flags.json) {
+      process.stdout.write(`${JSON.stringify({ results: [] }, null, 2)}\n`);
+    } else {
+      process.stdout.write(`\n${chalk.yellow('[skip]')} No installed Supermemory plugins found.\n\n`);
+    }
     return;
   }
 
@@ -1417,42 +1441,7 @@ export const uninstallCommand = defineCliCommand({
     },
   },
   async handler({ args, flags }) {
-    const dryRun = args['dry-run'] === true;
-    const installed = installedTargets();
-    let selectedIds = parseOnly(args.only);
-    if (args.all === true) selectedIds = installed.map((target) => target.id);
-
-    if (selectedIds.length === 0 && args.all !== true) {
-      if (!isInputInteractive() || flags.json) {
-        throw new Error('Choose targets with --all or --only claude,cursor,opencode,codex');
-      }
-      selectedIds = await chooseInstalledTargetIds('remove');
-    }
-    if (selectedIds.length === 0) {
-      process.stdout.write(`\n${chalk.yellow('[skip]')} No installed Supermemory plugins found.\n\n`);
-      return;
-    }
-
-    const results: UninstallResult[] = [];
-    for (const id of selectedIds) {
-      const target = TARGETS.find((candidate) => candidate.id === id);
-      if (!target) continue;
-      if (!installed.some((candidate) => candidate.id === id)) {
-        results.push({
-          id,
-          label: target.label,
-          status: 'skipped',
-          message: 'not installed',
-          steps: [],
-        });
-        continue;
-      }
-      results.push(await uninstallTarget(target, dryRun));
-    }
-
-    if (flags.json) process.stdout.write(`${JSON.stringify({ results }, null, 2)}\n`);
-    else printUninstallSummary(results, dryRun);
-    if (results.some((result) => result.status === 'failed')) process.exitCode = 1;
+    await handlePluginUninstall(args, flags);
   },
 });
 
@@ -1488,21 +1477,13 @@ export const pluginCommand = defineCliCommand({
       default: false,
     },
   },
+  subCommands: {
+    login: pluginLoginCommand,
+    uninstall: uninstallCommand,
+  },
   async handler({ args, flags, rawArgs }) {
-    const action = rawArgs.find((arg) => !arg.startsWith('-'));
-    if (action === 'login') {
-      await handlePluginLogin({
-        all: args.all === true,
-        only: args.only,
-        noBrowser: rawArgs.includes('--no-browser'),
-        json: flags.json === true,
-      });
-      return;
-    }
-    if (action === 'uninstall') {
-      await handlePluginUninstall(args, flags);
-      return;
-    }
+    const nestedCommand = rawArgs.find((arg) => !arg.startsWith('-'));
+    if (nestedCommand === 'login' || nestedCommand === 'uninstall') return;
 
     const dryRun = args['dry-run'] === true;
     const force = args.force === true;

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -104,11 +104,9 @@ const SUPERMEMORY_GLYPHS: Record<string, string[]> = {
 };
 
 const SUPERMEMORY_WORD = 'SUPERMEMORY';
-const BANNER_CELL = '\u2588\u2588';
-const BANNER_OUTLINE_CELL = '\u2592\u2592';
-const BANNER_SHADOW_CELL = '\u2591\u2591';
-const BANNER_FILL_COLORS = ['#B9F7FF', '#5BE9FF', '#22C9F4', '#168CF0', '#0B59D0'];
-const BANNER_OUTLINE_COLOR = '#0A86FF';
+const BANNER_CELL = '\u2588';
+const BANNER_SHADOW_CELL = '\u2591';
+const BANNER_FILL_COLORS = ['#D6FBFF', '#67E8F9', '#22D3EE', '#0EA5E9', '#2563EB', '#1D4ED8', '#123B9A'];
 const BANNER_SHADOW_COLOR = '#071D82';
 
 function printSupermemoryBanner(): void {
@@ -128,33 +126,23 @@ function printSupermemoryBanner(): void {
   process.stderr.write('\n');
   for (let row = 0; row < rowCount + 1; row++) {
     let rendered = '  ';
-    for (let column = -1; column < columnCount + 2; column++) {
+    for (let column = 0; column < columnCount + 1; column++) {
       const main = isFilled(row, column);
-      const outline =
-        !main &&
-        Array.from({ length: 3 }, (_, rowOffset) => rowOffset - 1).some((rowOffset) =>
-          Array.from({ length: 3 }, (_, columnOffset) => columnOffset - 1).some((columnOffset) =>
-            isFilled(row + rowOffset, column + columnOffset),
-          ),
-        );
-      const shadow = !main && !outline && isFilled(row - 1, column - 1);
-
+      const shadow = !main && isFilled(row - 1, column - 1);
       if (main) {
-        const color = BANNER_FILL_COLORS[Math.min(row, BANNER_FILL_COLORS.length - 1)] ?? '#22C9F4';
+        const color = BANNER_FILL_COLORS[Math.min(row, BANNER_FILL_COLORS.length - 1)] ?? '#22D3EE';
         rendered += chalk.hex(color)(BANNER_CELL);
-      } else if (outline) {
-        rendered += chalk.hex(BANNER_OUTLINE_COLOR)(BANNER_OUTLINE_CELL);
       } else if (shadow) {
         rendered += chalk.hex(BANNER_SHADOW_COLOR)(BANNER_SHADOW_CELL);
       } else {
-        rendered += '  ';
+        rendered += ' ';
       }
     }
     process.stderr.write(rendered + '\n');
   }
 
   const label = chalk.hex('#18BFFF')('>') + chalk.hex('#1775EF').bold(' PLUGINS');
-  const labelPadding = Math.max(2, columnCount * 2 - 2 - '> PLUGINS'.length);
+  const labelPadding = Math.max(2, columnCount - 2 - '> PLUGINS'.length);
   process.stderr.write(`${' '.repeat(labelPadding)}${label}\n\n`);
 }
 function clearRenderedPrompt(renderedLines: number): void {

--- a/apps/cli/src/help/index.ts
+++ b/apps/cli/src/help/index.ts
@@ -473,6 +473,37 @@ const FULL_COMMANDS: Record<string, CommandSchema> = {
   },
 };
 
+const NESTED_COMMANDS: Record<string, CommandSchema> = {
+  'plugin login': {
+    description: 'Connect installed Supermemory plugins with browser OAuth',
+    usage: 'supermemory plugin login [options]',
+    options: {
+      '--all': { type: 'boolean', default: false, description: 'Connect every installed Supermemory plugin' },
+      '--only': { type: 'string', description: 'Comma-separated targets: claude,cursor,opencode,codex' },
+      '--no-browser': { type: 'boolean', default: false, description: 'Show the OAuth URL instead of opening a browser' },
+    },
+    examples: [
+      'supermemory plugin login --all',
+      'supermemory plugin login --only codex',
+      'supermemory plugin login --all --no-browser',
+    ],
+  },
+  'plugin uninstall': {
+    description: 'Remove selected Supermemory plugin integrations',
+    usage: 'supermemory plugin uninstall [options]',
+    options: {
+      '--all': { type: 'boolean', default: false, description: 'Remove every installed Supermemory plugin' },
+      '--only': { type: 'string', description: 'Comma-separated targets: claude,cursor,opencode,codex' },
+      '--dry-run': { type: 'boolean', default: false, description: 'Show what would be removed without changing anything' },
+    },
+    examples: [
+      'supermemory plugin uninstall --all',
+      'supermemory plugin uninstall --only codex',
+      'supermemory plugin uninstall --all --dry-run',
+    ],
+  },
+};
+
 const SCOPED_COMMAND_NAMES = ['search', 'add', 'remember', 'forget', 'update', 'profile', 'whoami'];
 
 const CORE_COMMAND_NAMES = [
@@ -554,7 +585,7 @@ export function buildHelpJson(
 }
 
 export function getCommandSchema(commandName: string): CommandSchema | null {
-  return FULL_COMMANDS[commandName] ?? null;
+  return NESTED_COMMANDS[commandName] ?? FULL_COMMANDS[commandName] ?? null;
 }
 
 export function formatHelpText(

--- a/apps/cli/src/help/index.ts
+++ b/apps/cli/src/help/index.ts
@@ -434,8 +434,8 @@ const FULL_COMMANDS: Record<string, CommandSchema> = {
     examples: ['supermemory setup', 'supermemory setup --prompt'],
   },
   plugin: {
-    description: 'Install Supermemory integrations for Claude Code, Cursor, OpenCode, and Codex',
-    usage: 'supermemory plugin [--all|--only <targets>] [options]',
+    description: 'Install, connect, or remove Supermemory integrations',
+    usage: 'supermemory plugin [login|uninstall] [options]',
     options: {
       '--all': {
         type: 'boolean',
@@ -467,6 +467,8 @@ const FULL_COMMANDS: Record<string, CommandSchema> = {
       'supermemory plugin --all',
       'supermemory plugin --all --no-auth',
       'supermemory plugin --only claude,cursor --dry-run',
+      'supermemory plugin login',
+      'supermemory plugin uninstall',
     ],
   },
 };

--- a/apps/cli/src/help/index.ts
+++ b/apps/cli/src/help/index.ts
@@ -480,7 +480,11 @@ const NESTED_COMMANDS: Record<string, CommandSchema> = {
     options: {
       '--all': { type: 'boolean', default: false, description: 'Connect every installed Supermemory plugin' },
       '--only': { type: 'string', description: 'Comma-separated targets: claude,cursor,opencode,codex' },
-      '--no-browser': { type: 'boolean', default: false, description: 'Show the OAuth URL instead of opening a browser' },
+      '--no-browser': {
+        type: 'boolean',
+        default: false,
+        description: 'Show the OAuth URL instead of opening a browser',
+      },
     },
     examples: [
       'supermemory plugin login --all',
@@ -494,7 +498,11 @@ const NESTED_COMMANDS: Record<string, CommandSchema> = {
     options: {
       '--all': { type: 'boolean', default: false, description: 'Remove every installed Supermemory plugin' },
       '--only': { type: 'string', description: 'Comma-separated targets: claude,cursor,opencode,codex' },
-      '--dry-run': { type: 'boolean', default: false, description: 'Show what would be removed without changing anything' },
+      '--dry-run': {
+        type: 'boolean',
+        default: false,
+        description: 'Show what would be removed without changing anything',
+      },
     },
     examples: [
       'supermemory plugin uninstall --all',

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -185,11 +185,14 @@ async function main() {
     const commandTokens = rawArgs.filter((arg) => !arg.startsWith('-'));
     const parentCommand = commandTokens[0];
     const childCommand = commandTokens[1];
-    const parentDefinition = parentCommand ?
-      (subCommands[parentCommand] as {
-        subCommands?: Record<string, ReturnType<typeof defineCommand>>;
-      } | undefined)
-    : undefined;
+    const parentDefinition =
+      parentCommand ?
+        (subCommands[parentCommand] as
+          | {
+              subCommands?: Record<string, ReturnType<typeof defineCommand>>;
+            }
+          | undefined)
+      : undefined;
     const commandName =
       parentCommand && childCommand && parentDefinition?.subCommands?.[childCommand] ?
         `${parentCommand} ${childCommand}`

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -69,6 +69,23 @@ async function detectScope(): Promise<{
   }
 }
 
+function normalizePluginInstallArgs(args: string[]): string[] {
+  if (args[0] !== 'plugin' || args[1] === 'login' || args[1] === 'uninstall') return args;
+
+  const normalized: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    const nextArgument = args[index + 1];
+    if (!argument) continue;
+    if (argument === '--only' && nextArgument && !nextArgument.startsWith('-')) {
+      normalized.push(`${argument}=${nextArgument}`);
+      index += 1;
+    } else {
+      normalized.push(argument);
+    }
+  }
+  return normalized;
+}
 async function main() {
   process.on('exit', () => {
     if (process.stdin.isTTY && process.stdin.isRaw) {
@@ -165,7 +182,18 @@ async function main() {
   const rawArgs = process.argv.slice(2);
 
   if (rawArgs.includes('--help') && rawArgs.includes('--json')) {
-    const commandName = rawArgs.find((a) => !a.startsWith('--') && a in subCommands);
+    const commandTokens = rawArgs.filter((arg) => !arg.startsWith('-'));
+    const parentCommand = commandTokens[0];
+    const childCommand = commandTokens[1];
+    const parentDefinition = parentCommand ?
+      (subCommands[parentCommand] as {
+        subCommands?: Record<string, ReturnType<typeof defineCommand>>;
+      } | undefined)
+    : undefined;
+    const commandName =
+      parentCommand && childCommand && parentDefinition?.subCommands?.[childCommand] ?
+        `${parentCommand} ${childCommand}`
+      : parentCommand;
     if (commandName) {
       const schema = getCommandSchema(commandName);
       if (schema) {
@@ -256,8 +284,10 @@ async function main() {
     return;
   }
 
+  const commandArgs = normalizePluginInstallArgs(rawArgs);
+
   try {
-    await runCommand(cli, { rawArgs });
+    await runCommand(cli, { rawArgs: commandArgs });
   } catch (err) {
     if (err instanceof CliError) {
       outputError(err.code, err.message, errorFlags, err.hint);

--- a/apps/cli/src/lib/command.ts
+++ b/apps/cli/src/lib/command.ts
@@ -1,5 +1,5 @@
 import type { Span } from '@opentelemetry/api';
-import { defineCommand } from 'citty';
+import { defineCommand, type SubCommandsDef } from 'citty';
 import { getConfig } from './api.js';
 import { getEnforcedTags, type ResolvedConfig } from './config.js';
 import { ValidationError } from './errors.js';
@@ -38,7 +38,7 @@ export function defineCliCommand(options: {
     }
   >;
   noSpan?: boolean;
-  subCommands?: Record<string, ReturnType<typeof defineCommand>>;
+  subCommands?: SubCommandsDef;
   handler: (ctx: CommandContext) => Promise<void>;
 }) {
   const allArgs = {


### PR DESCRIPTION
Adds lifecycle management for installed Claude Code, Cursor, OpenCode, and Codex Supermemory integrations.

## Changes

- Add `supermemory plugin login` with explicit target selection and browser/no-browser OAuth flows.
- Add scoped, non-destructive `supermemory plugin uninstall` behavior with human and JSON summaries.
- Detect installed plugin artifacts and versions, update stale or unverifiable installations, and repair incomplete Codex installs.
- Add nested human/JSON help and consistent non-interactive output behavior.
- Update existing Claude marketplaces before installation, adding the marketplace only when it is not registered.

## Testing

- PASS — `PATH="$HOME/.bun/bin:$PATH" ./scripts/lint` with Supermemory API/tag environment variables unset.
  - TypeScript passed, ATTW reported `Types ok!`, and publint reported `All good!`.
- PASS — `./scripts/test` with Supermemory API/tag environment variables unset.
  - 7 suites passed, 6 skipped; 218 tests passed, 43 skipped; 3 snapshots passed.
- PASS — direct command-level lifecycle checks with isolated fake plugin installations and executables.
  - Verified nested login/uninstall human and JSON help, empty JSON uninstall, project-scoped Claude uninstall, and `--only` argument normalization.
  - Verified missing Claude marketplaces use update → add → install; unrelated update failures stop without adding/installing.
  - Verified non-interactive no-browser URL emission and bounded callback waiting.
- Not run against live external systems: real Claude marketplace installation, live OAuth completion, and destructive live plugin uninstall.

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/fc7700cd-bb25-46f0-898c-f75d2deb1054)
- Requested by: Mahesh Sanikommu (mahesh@supermemory.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
