### PR TITLE
Automate version-based npm releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,68 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - package.json
+
+concurrency:
+  group: create-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: create release
+    runs-on: ubuntu-latest
+    if: github.repository == 'supermemoryai/sdk-ts'
+    permissions:
+      actions: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for version change
+        id: version
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          current_version=$(node -p "require('./package.json').version")
+          previous_version=$(git show "$BEFORE_SHA:package.json" 2>/dev/null | node -e "let data = ''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => console.log(JSON.parse(data).version));" || true)
+
+          echo "current=$current_version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$current_version" >> "$GITHUB_OUTPUT"
+
+          if [ "$current_version" != "$previous_version" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub release
+        id: release
+        if: steps.version.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; skipping."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          else
+            gh release create "$TAG" \
+              --target "$GITHUB_SHA" \
+              --title "$TAG" \
+              --generate-notes
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish packages
+        if: steps.release.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: gh workflow run publish-npm.yml --ref main -f path=. -f release_tag="$TAG"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,8 +6,11 @@ on:
   workflow_dispatch:
     inputs:
       path:
-        description: The path to run the release in, e.g. '.' or 'packages/mcp-server'
-        required: true
+        description: The path to release, e.g. '.' or 'packages/mcp-server'. Leave empty to release all packages.
+        required: false
+      release_tag:
+        description: The GitHub release tag to upload assets to when dispatched by another workflow.
+        required: false
 
   release:
     types: [published]
@@ -56,8 +59,10 @@ jobs:
           INPUT_PATH: ${{ github.event.inputs.path }}
 
       - name: Upload MCP Server DXT GitHub release asset
+        if: github.event_name == 'release' || (github.event.inputs.release_tag != '' && github.event.inputs.path != '.')
         run: |
-          gh release upload ${{ github.event.release.tag_name }} \
+          gh release upload "$RELEASE_TAG" \
             packages/mcp-server/supermemory_api.mcpb
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}

--- a/packages/mcp-server/build
+++ b/packages/mcp-server/build
@@ -42,7 +42,7 @@ node scripts/copy-bundle-files.cjs
 
 # install runtime deps
 cd dist-bundle
-npm install
+npm install --allow-remote=root
 cd ..
 
 # pack bundle


### PR DESCRIPTION
## Stack Context

This PR makes the npm release pipeline compatible with npm 12 and automates root package releases from version changes on `main`.

## What?

- Allow the explicitly declared remote `jq-web` tarball during the MCP bundle install.
- Create a `v<version>` GitHub release when the root `package.json` version changes on `main`.
- Explicitly dispatch the npm publisher after workflow-created releases.
- Publish only the root package for root-only version changes and avoid uploading an MCP asset when it was not built.

## Why?

The `v4.25.2` publish job failed after `npm@latest` advanced to npm 12, which disables remote URL dependencies by default. The repository also relied on manually created releases, allowing release tags to drift from the version in `package.json`.

The remote dependency opt-in is scoped to root-declared dependencies, and generated release tags now come directly from `package.json`.

## Validation

- `bash -n packages/mcp-server/build`
- Parsed both modified workflow YAML files
- `git diff --check`
