### PR TITLE
Fix publish workflow paths JSON

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -54,7 +54,7 @@ jobs:
           else
             PATHS_RELEASED='[\".\", \"packages/mcp-server\"]'
           fi
-          yarn tsn scripts/publish-packages.ts "{ \"paths_released\": \"$PATHS_RELEASED\" }"
+          yarn tsn scripts/publish-packages.ts "{ \"paths_released\": $PATHS_RELEASED }"
         env:
           INPUT_PATH: ${{ github.event.inputs.path }}
 

--- a/scripts/publish-packages.ts
+++ b/scripts/publish-packages.ts
@@ -61,12 +61,7 @@ function main() {
     console.error(JSON.stringify(outputs, null, 2));
     throw new Error('Expected outputs to contain a truthy `paths_released` property');
   }
-  if (typeof rawPaths !== 'string') {
-    console.error(JSON.stringify(outputs, null, 2));
-    throw new Error('Expected outputs `paths_released` property to be a JSON string');
-  }
-
-  const paths = JSON.parse(rawPaths);
+  const paths = typeof rawPaths === 'string' ? JSON.parse(rawPaths) : rawPaths;
   if (!Array.isArray(paths)) {
     console.error(JSON.stringify(outputs, null, 2));
     throw new Error('Expected outputs `paths_released` property to be an array');


### PR DESCRIPTION
## Stack Context

Follow-up to #98, which automated version-based npm releases.

## What?

Pass `paths_released` as a JSON array and allow the publishing script to consume either the new array format or the legacy JSON-string format.

## Why?

The workflow wrapped an already encoded array in JSON quotes. Shell quote processing produced invalid JSON such as `{"paths_released":"["."]"}`, causing `JSON.parse` to fail before the build or publish began.

## Validation

- Verified the exact shell-generated payload for root-only and all-package publishing
- `yarn tsc --noEmit --pretty false`
- Workflow YAML parsing
- `git diff --check`
