### PR TITLE
Publish packages to npmjs registry

### DIFF
--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -56,4 +56,4 @@ else
 fi
 
 # Publish with the appropriate tag using npm trusted publishing (OIDC provenance)
-npm publish --tag "$TAG" --provenance
+npm publish --registry https://registry.npmjs.org --tag "$TAG" --provenance


### PR DESCRIPTION
## Stack Context

Follow-up to #98 and #99, which automated releases and fixed the publish payload.

## What?

Explicitly publish packages to `https://registry.npmjs.org`.

## Why?

The release build reaches `npm publish`, but Yarn configuration causes npm to target `https://registry.yarnpkg.com`. That registry cannot use the package's npm trusted publisher and fails with `ENEEDAUTH`.

Pinning the registry on the publish command ensures npm uses the configured OIDC trusted publisher.

## Validation

- `bash -n bin/publish-npm`
- `git diff --check`
