### PR TITLE
fix: repair main-branch npm publish automation

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -50,18 +50,19 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists; skipping."
-            echo "created=false" >> "$GITHUB_OUTPUT"
+            echo "Release $TAG already exists; continuing to publish."
           else
             gh release create "$TAG" \
               --target "$GITHUB_SHA" \
               --title "$TAG" \
               --generate-notes
-            echo "created=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # GITHUB_TOKEN-created releases do not trigger other workflows, so we
+      # must dispatch Publish NPM explicitly. Only the root package is published
+      # here (path=.); use a full release event / empty path to also publish mcp.
       - name: Publish packages
-        if: steps.release.outputs.created == 'true'
+        if: steps.version.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -50,11 +50,11 @@ jobs:
       - name: Publish to NPM
         run: |
           if [ -n "$INPUT_PATH" ]; then
-            PATHS_RELEASED="[\"$INPUT_PATH\"]"
+            PAYLOAD="$(jq -nc --arg p "$INPUT_PATH" '{paths_released:[$p]}')"
           else
-            PATHS_RELEASED='[\".\", \"packages/mcp-server\"]'
+            PAYLOAD='{"paths_released":[".","packages/mcp-server"]}'
           fi
-          yarn tsn scripts/publish-packages.ts "{ \"paths_released\": $PATHS_RELEASED }"
+          yarn tsn scripts/publish-packages.ts "$PAYLOAD"
         env:
           INPUT_PATH: ${{ github.event.inputs.path }}
 

--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -8,6 +8,13 @@ cd dist
 # Get package name and version from package.json
 PACKAGE_NAME="$(jq -r -e '.name' ./package.json)"
 VERSION="$(jq -r -e '.version' ./package.json)"
+REGISTRY="https://registry.npmjs.org"
+
+# Skip if this exact version is already published (makes re-runs safe).
+if npm view "$PACKAGE_NAME@$VERSION" version --registry "$REGISTRY" >/dev/null 2>&1; then
+  echo "$PACKAGE_NAME@$VERSION is already published; skipping."
+  exit 0
+fi
 
 # Get latest version from npm
 #
@@ -19,7 +26,7 @@ VERSION="$(jq -r -e '.version' ./package.json)"
 #     "detail": "'the_package' is not in this registry..."
 #   }
 # }
-NPM_INFO="$(npm view "$PACKAGE_NAME" version --json 2>/dev/null || true)"
+NPM_INFO="$(npm view "$PACKAGE_NAME" version --json --registry "$REGISTRY" 2>/dev/null || true)"
 
 # Check if we got an E404 error
 if echo "$NPM_INFO" | jq -e '.error.code == "E404"' > /dev/null 2>&1; then
@@ -56,4 +63,4 @@ else
 fi
 
 # Publish with the appropriate tag using npm trusted publishing (OIDC provenance)
-npm publish --registry https://registry.npmjs.org --tag "$TAG" --provenance
+npm publish --registry "$REGISTRY" --tag "$TAG" --provenance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supermemory",
-  "version": "4.25.3",
+  "version": "4.25.4",
   "description": "The official TypeScript library for the Supermemory API",
   "author": "Supermemory <dhravya@supermemory.com>",
   "types": "dist/index.d.ts",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '4.25.0'; // x-release-please-version
+export const VERSION = '4.25.4'; // x-release-please-version


### PR DESCRIPTION
## Summary

- Fix broken `paths_released` JSON in Publish NPM (manual and full-package runs failed to parse).
- Make create-release still dispatch publish when the version changed, even if the GitHub release already exists.
- Skip re-publishing versions already on npmjs, and keep the npm registry pin.
- Bump `supermemory` to **4.25.4** so merging this PR exercises Create Release → Publish NPM end-to-end.

## How publish works after this

1. Merge to `main` with a `package.json` version change
2. **Create Release** creates `v4.25.4` (or continues if it already exists)
3. Dispatches **Publish NPM** with `path=.`
4. Publishes `supermemory@4.25.4` to npmjs via OIDC trusted publishing

## Test plan

- [ ] Merge this PR to `main`
- [ ] Confirm **Create Release** succeeds and creates `v4.25.4`
- [ ] Confirm **Publish NPM** succeeds
- [ ] Verify `npm view supermemory version` returns `4.25.4`