### PR TITLE
Fix plugin uninstall terminal cleanup

### DIFF
--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -178,6 +178,7 @@ function withRawKeypress<T>(
     const cleanup = (result: T) => {
       input.off('keypress', handler);
       if (input.setRawMode && !hadRawMode) input.setRawMode(false);
+      input.pause();
       process.stderr.write('\u001B[?25h');
       resolve(result);
     };


### PR DESCRIPTION
## What changed

Pause the interactive plugin selector's stdin stream during cleanup.

## Why

The selector removed its keypress handler and restored raw mode, but left stdin active. Successful plugin uninstall commands printed their summary and then kept the Node process alive instead of returning to the shell.