### PR TITLE
chore: release supermemory 5.0.0-rc.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "supermemory",
-  "version": "5.0.0-rc.3",
+  "version": "5.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "supermemory",
-      "version": "5.0.0-rc.3",
+      "version": "5.0.0-rc.4",
       "dependencies": {
         "zod": "^3.25.65 || ^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supermemory",
-  "version": "5.0.0-rc.3",
+  "version": "5.0.0-rc.4",
   "author": "Speakeasy",
   "bin": {
     "supermemory": "bin/cli.mjs"


### PR DESCRIPTION
Bump the sdk-ts package version from 5.0.0-rc.3 to 5.0.0-rc.4.

This release lets the sdk-ts publish workflow bundle the restored plugin lifecycle from supermemoryai/mono#2943.

Dependency: merge only after supermemoryai/mono#2943 is merged so the workflow checks out the updated Mono CLI.