### PR TITLE
ci: verify the bundled CLI command surface before publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -82,6 +82,10 @@ jobs:
           chmod +x bin/cli.mjs
           node bin/cli.mjs --version
 
+      - name: Verify CLI command surface
+        if: steps.meta.outputs.publish == 'true'
+        run: bun ../mono/apps/cli/scripts/verify-surface.ts "$(pwd)/bin/cli.mjs"
+
       - name: Verify tarball contents
         if: steps.meta.outputs.publish == 'true'
         run: |


### PR DESCRIPTION
Depends on supermemoryai/mono#3220 — merge that first.

## Why

`npx supermemory local` broke in `5.0.0-rc.1` and nothing caught it.

The `local` launcher was an `if (process.argv[2] === "local")` shim on top of this repo's checked-in `bin/cli`. Commit `39a16be` deleted that file (`bin/cli | 65608 ------`) and switched to a bundle built from the monorepo, which never had a `local` command. The shim went with the file.

The publish smoke test is this:

```
node bin/cli.mjs --version
```

Which passes fine on a CLI that has lost half its commands. So a broken bundle shipped to npm, and the first signal was someone running the command.

## What this adds

One step, running the check the CLI owns in mono. It diffs the built bundle's own `help --json` against a committed ledger of tracked commands — missing ones fail the publish, new ones print a nudge to add them.

Validated both ways against real artifacts:

```
5.0.0-rc.3 published bundle →  ✗ missing 1 command(s): local   exit=1
current build              →  ✓ all 24 tracked commands        exit=0
```

It catches the exact regression that shipped.

`--version` stays — it's still a useful "does this even execute" check. It just isn't the only gate any more.

## Verified

Simulated the full publish path locally against the mono branch: bundle → shebang → `--version` → surface check. The script resolves its ledger relative to its own location, so invoking it from this repo's working directory works as written.

Mono's CI also runs the same check on both bundle shapes, so most breakage should now fail there rather than reaching this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfVCx97GJvfMGzv88pVvNU