### PR TITLE
Revert CLI command surface check

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -82,10 +82,6 @@ jobs:
           chmod +x bin/cli.mjs
           node bin/cli.mjs --version
 
-      - name: Verify CLI command surface
-        if: steps.meta.outputs.publish == 'true'
-        run: bun ../mono/apps/cli/scripts/verify-surface.ts "$(pwd)/bin/cli.mjs"
-
       - name: Verify tarball contents
         if: steps.meta.outputs.publish == 'true'
         run: |


### PR DESCRIPTION
Reverts the step added in #107.

It invoked `../mono/apps/cli/scripts/verify-surface.ts`, which is no longer being added to the monorepo — supermemoryai/mono#3220 was reduced to just the `local` command restore. Left in place, this step would fail every publish on a missing file.

`node bin/cli.mjs --version` remains the smoke test.

Worth knowing: the publish run triggered by #107 merging (`5.0.0-rc.4`) failed before reaching this step, at the `supermemoryai/mono` checkout — `Bad credentials`, i.e. `MONO_READ_TOKEN` is expired or revoked. That's unrelated to this revert and still needs fixing; `5.0.0-rc.4` is not on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfVCx97GJvfMGzv88pVvNU